### PR TITLE
Add support for map params

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ val uri = "http://example.com".addParams(p)
 uri.toString //This is: http://example.com/?key=true&key2=false
 ```
 
+```scala
+import com.netaporter.uri.dsl._
+val p = Map("key" -> true, "key2" -> false)
+val uri = "http://example.com".addParams(p)
+uri.toString //This is: http://example.com/?key=true&key2=false
+```
+
 ### Paths
 
 ```scala

--- a/shared/src/main/scala/com/netaporter/uri/Uri.scala
+++ b/shared/src/main/scala/com/netaporter/uri/Uri.scala
@@ -45,13 +45,16 @@ case class Uri (
     case (n, v) => copy(query = query.addParam(n, Some(v.toString)))
   }
 
-  def addParams(kvs: Seq[(String, Any)]) = {
+  def addParams(kvs: Seq[(String, Any)]): Uri = {
     val cleanKvs = kvs.filterNot(_._2 == None).map {
       case (k, Some(v)) => (k, Some(v.toString))
       case (k, v) => (k, Some(v.toString))
     }
     copy(query = query.addParams(cleanKvs))
   }
+
+  def addParams(kvs: Map[String, Any]): Uri =
+    addParams(kvs.toSeq)
 
   def addParam(kv: Param) = copy(query = query.addParam(kv))
 

--- a/shared/src/test/scala/com/netaporter/uri/DslTests.scala
+++ b/shared/src/test/scala/com/netaporter/uri/DslTests.scala
@@ -164,8 +164,23 @@ class DslTests extends FlatSpec with Matchers {
     uri.toString should equal("http://example.com?name=true&key2=false")
   }
 
+  "A map of query params" should "get added successsfully" in {
+    val p = Map("name" -> true, "key2" -> false)
+    val uri = "http://example.com".addParams(p)
+    uri.query.params("name") should equal(Some("true") :: Nil)
+    uri.query.params("key2") should equal(Some("false") :: Nil)
+    uri.toString should equal("http://example.com?name=true&key2=false")
+  }
+
   "A list of query params" should "get added to a URL already with query params successsfully" in {
     val p = ("name", true) :: ("key2", false) :: Nil
+    val uri = ("http://example.com" ? ("name" -> Some("param1"))).addParams(p)
+    uri.query.params("name") should equal(Vector(Some("param1"), Some("true")))
+    uri.query.params("key2") should equal(Some("false") :: Nil)
+  }
+
+  "A map of query params" should "get added to a URL already with query params successsfully" in {
+    val p = Map("name" -> true, "key2" -> false)
     val uri = ("http://example.com" ? ("name" -> Some("param1"))).addParams(p)
     uri.query.params("name") should equal(Vector(Some("param1"), Some("true")))
     uri.query.params("key2") should equal(Some("false") :: Nil)


### PR DESCRIPTION
`addParams` for Map which just delegates to the Seq method.
Its also possible to do it without relying on the other method.
What do you think @theon ?