### PR TITLE
Fix - percent encode ' ', '%', '<', '>', '[', ']', '#', '{', '}', '^', '`', '|' by default in the fragment

### DIFF
--- a/shared/src/main/scala/com/netaporter/uri/encoding/PercentEncoder.scala
+++ b/shared/src/main/scala/com/netaporter/uri/encoding/PercentEncoder.scala
@@ -23,19 +23,20 @@ case class PercentEncoder(charsToEncode: Set[Char] = DEFAULT_CHARS_TO_ENCODE) ex
 object PercentEncoder {
 
   val USER_INFO_CHARS_TO_ENCODE = Set (
-    ' ', '%', '<', '>', '[', ']', '#', '%', '{', '}', '^', '`', '|', '?', '@', ':', '/'
+    ' ', '%', '<', '>', '[', ']', '#', '{', '}', '^', '`', '|', '?', '@', ':', '/'
   )
 
   val PATH_CHARS_TO_ENCODE = Set (
-    ' ', '%', '<', '>', '[', ']', '#', '%', '{', '}', '^', '`', '|', '?'
+    ' ', '%', '<', '>', '[', ']', '#', '{', '}', '^', '`', '|', '?'
   )
 
   val QUERY_CHARS_TO_ENCODE = Set (
-    ' ', '%', '<', '>', '[', ']', '#', '%', '{', '}', '^', '`', '|', '&', '\\', '+', '='
+    ' ', '%', '<', '>', '[', ']', '#', '{', '}', '^', '`', '|', '&', '\\', '+', '='
   )
 
-  val FRAGMENT_CHARS_TO_ENCODE = Set('#')
-
+  val FRAGMENT_CHARS_TO_ENCODE = Set (
+    ' ', '%', '<', '>', '[', ']', '#', '{', '}', '^', '`', '|'
+  )
 
   val GEN_DELIMS = Set(':', '/', '?',  '#', '[', ']', '@')
   val SUB_DELIMS  = Set('!', '$', '&', '\'', '(', ')', '*', '+', ',', ';', '=')

--- a/shared/src/test/scala/com/netaporter/uri/EncodingTests.scala
+++ b/shared/src/test/scala/com/netaporter/uri/EncodingTests.scala
@@ -71,8 +71,8 @@ class EncodingTests extends FlatSpec with Matchers {
   }
 
   "Fragments" should "be percent encoded" in {
-    val uri = "http://theon.github.com/uris-in-scala.html" ? ("chinese" -> "网址")
-    uri.toString should equal ("http://theon.github.com/uris-in-scala.html?chinese=%E7%BD%91%E5%9D%80")
+    val uri = "http://theon.github.com/uris-in-scala.html" `#` "chinese# 网址"
+    uri.toString should equal ("http://theon.github.com/uris-in-scala.html#chinese%23%20%E7%BD%91%E5%9D%80")
   }
 
   "Percent encoding with custom reserved characters" should "be easy" in {


### PR DESCRIPTION
fragment    = *( pchar / "/" / "?" )