### PR TITLE
Mark spray-json library as optional dependency and bump the project version up

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,6 +575,12 @@ uri.apexDomain // This returns Some("google.co.uk")
 
 **Note:** *Currently not supported for scala-js*
 
+**Note:** *To use it spray-json dependency is required*
+
+```scala
+"io.spray" %% "spray-json" % "1.3.2"
+```
+
 `scala-uri` uses the list of public suffixes from [publicsuffix.org](https://publicsuffix.org) to allow you to identify
 the TLD of your absolute URIs.
 

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ val sharedSettings = Seq(
 
 val jvmSettings = Seq(
   libraryDependencies ++= Seq(
-    "io.spray" %%  "spray-json" % "1.3.4"
+    "io.spray" %%  "spray-json" % "1.3.4" % Optional
   )
 )
 

--- a/project/build_dependencies.sbt
+++ b/project/build_dependencies.sbt
@@ -1,1 +1,1 @@
-libraryDependencies += "io.spray" %%  "spray-json" % "1.3.2"
+libraryDependencies += "io.spray" %%  "spray-json" % "1.3.2" % Optional

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := sys.props.getOrElse("scala.uri.ver", "1.4.5")
+version in ThisBuild := sys.props.getOrElse("scala.uri.ver", "1.4.6-SNAPSHOT")


### PR DESCRIPTION
**Description**

This PR marks `spray-json` as an optional dependency.

With this PR the dependency graph will look the following way:

<img width="525" alt="pull-38" src="https://user-images.githubusercontent.com/4929546/59727135-76122000-9202-11e9-98a0-4e6281f8e580.png">

The current master branch graph:

<img width="525" alt="master" src="https://user-images.githubusercontent.com/4929546/59732465-54bc2e80-9218-11e9-8770-3b39d1334623.png">

Partially covers https://github.com/lemonlabsuk/scala-uri/issues/37
