### PR TITLE
Add cats support. Make Authority.userInfo optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Slack](https://lemonlabs.io/slack/badge.svg)](https://lemonlabs.io/slack)
 [![Maven Central](https://img.shields.io/maven-central/v/io.lemonlabs/scala-uri_2.13/2)](https://maven-badges.herokuapp.com/maven-central/io.lemonlabs/scala-uri_2.12)
 [![Scala.js](https://www.scala-js.org/assets/badges/scalajs-0.6.17.svg)](#scalajs-support)
+[![Cats Friendly Badge](https://typelevel.org/cats/img/cats-badge-tiny.png)](#cats-support) 
 
 `scala-uri` is a small Scala library that helps you work with URIs. It has the following features:
 
@@ -22,6 +23,7 @@
  * Support for [mailto](#mailto) URLs
  * Support for [data](#data-urls) URLs as defined in [RFC2397](https://tools.ietf.org/html/rfc2397)
  * Support for [Scala.js](#scalajs-support)
+ * Support for [cats](#cats-support)
  * No dependencies on existing web frameworks
 
 To include it in your SBT project from maven central:
@@ -761,6 +763,16 @@ uri5.toString //This is: http://theon.github.com/scala-uri#user-1
 
 See [scala-uri-scalajs-example](https://github.com/lemonlabsuk/scala-uri-scalajs-example) for usage
 
+## Cats Support
+
+scala-uri provides type class instances of `cats.Eq`, `cats.Show` and `cats.Order` for:
+`Uri `, `Url`, `RelativeUrl`, `UrlWithAuthority`, `ProtocolRelativeUrl`, `AbsoluteUrl`, 
+`UrlWithoutAuthority`, `SimpleUrlWithoutAuthority`, `DataUrl`, `Urn`, `Authority`, `UserInfo`, 
+`Host`, `DomainName`, `IpV4`, `IpV6`, `MediaType`, `Path`, `UrlPath`, `AbsoluteOrEmptyPath`, 
+`RootlessPath`, `AbsolutePath`, `UrnPath`, `QueryString`
+
+The type class instances exist in the companion objects for these types.
+
 ## Including scala-uri your project
 
 `scala-uri` `2.x.x` is currently built with support for Scala `2.13.x`, Scala `2.12.x` and Scala.js `0.6.17+` 
@@ -797,8 +809,14 @@ Contributions to `scala-uri` are always welcome. Check out the [Contributing Gui
  * *Binary Incompatibility*: The case class `UrlWithoutAuthority` has been renamed `SimpleUrlWithoutAuthority`.
    There is now a trait called `UrlWithoutAuthority`. This trait has a companion object with `apply`, `unapply` and `parse`
    methods, so it mostly can be used in the same way as the previous case class.
- * Parsing a Data URL will now return an instance of [`DataUrl`](#data-urls) rather than `UrlWithoutAuthority`
+ * *Binary Incompatibility*: Parsing a Data URL will now return an instance of [`DataUrl`](#data-urls) rather than `UrlWithoutAuthority`
+ * *Binary Incompatibility*: `UserInfo.user` is now of type `String` rather than `Option[String]`
+   * *Binary Incompatibility*`Authority.userInfo` is now of type `Option[UserInfo]`
+   * *Binary Incompatibility*: `UserInfo.empty` method removed
  * The [URL builder DSL](#url-builder-dsl) has been deprecated in favour of the [Typesafe URL builder DSL](#typesafe-url-builder-dsl)
+ * `Authority.parse` no longer expects it's string argument to start with `//`, as this is not part of the Authority, it is a delimiter. See [RFC 3986](https://www.ietf.org/rfc/rfc3986.txt)
+ * `UserInfo.parse` no longer expects it's string argument to end with a `@`, as this is not part of the UserInfo, it is a delimiter. See [RFC 3986](https://www.ietf.org/rfc/rfc3986.txt)
+ * `QueryString.toString` no longer returns a leading `?`, as this is not part of the query string, it is a delimiter. See [RFC 3986](https://www.ietf.org/rfc/rfc3986.txt)
  * Forward slashes in paths are now percent encoded by default.
    This means `Url.parse("/%2F/").toString` returns `"/%2F/"` rather than `///` in previous versions
    To return to the previous behavior, you can bring a `UriConfig` like so into scope

--- a/project/MimaSettings.scala
+++ b/project/MimaSettings.scala
@@ -16,17 +16,15 @@ object MimaSettings {
 
   val mimaSettings = MimaPlugin.mimaDefaultSettings ++ Seq(
     mimaPreviousArtifacts := {
-      CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, scalaMajor)) if scalaMajor <= 13 =>
-          previousVersions.map { organization.value % s"${name.value}_${scalaBinaryVersion.value}" % _ }
-        case _ => Set.empty
-      }
+      if (VersionNumber(scalaVersion.value).matchesSemVer(SemanticSelector("<=2.13")))
+        previousVersions.map { organization.value % s"${name.value}_${scalaBinaryVersion.value}" % _ } else
+        Set.empty
     },
     mimaBinaryIssueFilters ++= {
-      CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, 12)) =>
+      VersionNumber(scalaVersion.value) match {
+        case v if v.matchesSemVer(SemanticSelector("<2.13")) =>
           mimaExcludes ++ Seq(
-            // In scala 2.12 adding a method to a value class breaks binary compatibility (see here: ).
+            // In scala 2.12 adding a method to a value class breaks binary compatibility (see here: https://github.com/lightbend/mima/issues/135).
             // This was fixed in scala 2.13, which is why we only exclude from mima for 2.12
             ProblemFilters.exclude[DirectMissingMethodProblem]("io.lemonlabs.uri.typesafe.dsl.TypesafeUrlDsl.*")
           )

--- a/shared/src/main/scala/io/lemonlabs/uri/Authority.scala
+++ b/shared/src/main/scala/io/lemonlabs/uri/Authority.scala
@@ -1,16 +1,18 @@
 package io.lemonlabs.uri
 
+import cats.implicits._
+import cats.{Eq, Order, Show}
 import io.lemonlabs.uri.config.UriConfig
 import io.lemonlabs.uri.parsing.UrlParser
 
 import scala.util.Try
 
-case class Authority(userInfo: UserInfo, host: Host, port: Option[Int])(
+case class Authority(userInfo: Option[UserInfo], host: Host, port: Option[Int])(
     implicit config: UriConfig = UriConfig.default
 ) {
 
-  def user: Option[String] = userInfo.user
-  def password: Option[String] = userInfo.password
+  def user: Option[String] = userInfo.map(_.user)
+  def password: Option[String] = userInfo.flatMap(_.password)
 
   /**
     * Returns the longest public suffix for the host in this URI. Examples include:
@@ -73,13 +75,8 @@ case class Authority(userInfo: UserInfo, host: Host, port: Option[Int])(
     host.longestSubdomain
 
   private[uri] def toString(c: UriConfig, hostToString: Host => String): String = {
-    val userInfo = for {
-      userStr <- user
-      userStrEncoded = c.userInfoEncoder.encode(userStr, c.charset)
-      passwordStrEncoded = password.map(p => ":" + c.userInfoEncoder.encode(p, c.charset)).getOrElse("")
-    } yield userStrEncoded + passwordStrEncoded + "@"
-
-    userInfo.getOrElse("") + hostToString(host) + port.map(":" + _).getOrElse("")
+    val userInfoStr = userInfo.map(_.toString(c) + "@").getOrElse("")
+    userInfoStr + hostToString(host) + port.map(":" + _).getOrElse("")
   }
 
   /**
@@ -99,16 +96,16 @@ case class Authority(userInfo: UserInfo, host: Host, port: Option[Int])(
 object Authority {
 
   def apply(host: String)(implicit config: UriConfig): Authority =
-    new Authority(UserInfo.empty, Host.parse(host), port = None)
+    new Authority(None, Host.parse(host), port = None)
 
   def apply(host: Host)(implicit config: UriConfig): Authority =
-    new Authority(UserInfo.empty, host, port = None)
+    new Authority(None, host, port = None)
 
   def apply(host: String, port: Int)(implicit config: UriConfig): Authority =
-    new Authority(UserInfo.empty, Host.parse(host), Some(port))
+    new Authority(None, Host.parse(host), Some(port))
 
   def apply(host: Host, port: Int)(implicit config: UriConfig): Authority =
-    new Authority(UserInfo.empty, host, Some(port))
+    new Authority(None, host, Some(port))
 
   def parseTry(s: CharSequence)(implicit config: UriConfig = UriConfig.default): Try[Authority] =
     UrlParser.parseAuthority(s.toString)
@@ -118,17 +115,35 @@ object Authority {
 
   def parse(s: CharSequence)(implicit config: UriConfig = UriConfig.default): Authority =
     parseTry(s).get
+
+  implicit val eqAuthority: Eq[Authority] = Eq.fromUniversalEquals
+  implicit val showAuthority: Show[Authority] = Show.fromToString
+  implicit val orderAuthority: Order[Authority] = Order.by { authority =>
+    (authority.userInfo, authority.host, authority.port)
+  }
 }
 
-case class UserInfo(user: Option[String], password: Option[String])
+case class UserInfo(user: String, password: Option[String])(
+    implicit config: UriConfig = UriConfig.default
+) {
+  private[uri] def toString(c: UriConfig): String = {
+    val userStrEncoded = c.userInfoEncoder.encode(user, c.charset)
+    val passwordStrEncoded = password.map(p => ":" + c.userInfoEncoder.encode(p, c.charset)).getOrElse("")
+    userStrEncoded + passwordStrEncoded
+  }
+
+  override def toString: String =
+    toString(config)
+
+  def toStringRaw: String =
+    toString(config.withNoEncoding)
+}
 object UserInfo {
   def apply(user: String): UserInfo =
-    new UserInfo(Some(user), password = None)
+    new UserInfo(user, password = None)
 
   def apply(user: String, password: String): UserInfo =
-    new UserInfo(Some(user), Some(password))
-
-  def empty = UserInfo(None, None)
+    new UserInfo(user, Some(password))
 
   def parseTry(s: CharSequence)(implicit config: UriConfig = UriConfig.default): Try[UserInfo] =
     UrlParser.parseUserInfo(s.toString)
@@ -138,4 +153,10 @@ object UserInfo {
 
   def parse(s: CharSequence)(implicit config: UriConfig = UriConfig.default): UserInfo =
     parseTry(s).get
+
+  implicit val eqUserInfo: Eq[UserInfo] = Eq.fromUniversalEquals
+  implicit val showUserInfo: Show[UserInfo] = Show.fromToString
+  implicit val orderUserInfo: Order[UserInfo] = Order.by { userInfo =>
+    (userInfo.user, userInfo.password)
+  }
 }

--- a/shared/src/main/scala/io/lemonlabs/uri/Host.scala
+++ b/shared/src/main/scala/io/lemonlabs/uri/Host.scala
@@ -1,5 +1,7 @@
 package io.lemonlabs.uri
 
+import cats.implicits._
+import cats.{Eq, Order, Show}
 import io.lemonlabs.uri.config.UriConfig
 import io.lemonlabs.uri.inet._
 import io.lemonlabs.uri.parsing.UrlParser
@@ -100,6 +102,10 @@ object Host {
 
   def unapply(host: Host): Option[String] =
     Some(host.toString)
+
+  implicit val eqHost: Eq[Host] = Eq.fromUniversalEquals
+  implicit val showHost: Show[Host] = Show.fromToString
+  implicit val orderHost: Order[Host] = Order.by(_.value)
 }
 
 final case class DomainName(value: String)(implicit val conf: UriConfig = UriConfig.default)
@@ -225,6 +231,10 @@ object DomainName {
     parseTry(s).get
 
   def empty: DomainName = DomainName("")
+
+  implicit val eqDomainName: Eq[DomainName] = Eq.fromUniversalEquals
+  implicit val showDomainName: Show[DomainName] = Show.fromToString
+  implicit val orderDomainName: Order[DomainName] = Order.by(_.value)
 }
 
 final case class IpV4(octet1: Byte, octet2: Byte, octet3: Byte, octet4: Byte)(implicit val conf: UriConfig =
@@ -268,6 +278,10 @@ object IpV4 {
 
   def parse(s: CharSequence)(implicit config: UriConfig = UriConfig.default): IpV4 =
     parseTry(s).get
+
+  implicit val eqIpV4: Eq[IpV4] = Eq.fromUniversalEquals
+  implicit val showIpV4: Show[IpV4] = Show.fromToString
+  implicit val orderIpV4: Order[IpV4] = Order.by(_.octets)
 }
 
 final case class IpV6(piece1: Char,
@@ -404,4 +418,8 @@ object IpV6 {
 
   def parse(s: CharSequence)(implicit config: UriConfig = UriConfig.default): IpV6 =
     parseTry(s).get
+
+  implicit val eqIpV6: Eq[IpV6] = Eq.fromUniversalEquals
+  implicit val showIpV6: Show[IpV6] = Show.fromToString
+  implicit val orderIpV6: Order[IpV6] = Order.by(_.pieces)
 }

--- a/shared/src/main/scala/io/lemonlabs/uri/MediaType.scala
+++ b/shared/src/main/scala/io/lemonlabs/uri/MediaType.scala
@@ -1,5 +1,8 @@
 package io.lemonlabs.uri
 
+import cats.implicits._
+import cats.{Eq, Order, Show}
+
 case class MediaType(rawValue: Option[String], parameters: Vector[(String, String)]) {
 
   /**
@@ -55,4 +58,12 @@ case class MediaType(rawValue: Option[String], parameters: Vector[(String, Strin
 
   override def toString: String =
     rawValue.getOrElse("") + parameters.foldLeft("") { case (str, (key, v)) => s"$str;$key=$v" }
+}
+
+object MediaType {
+  implicit val eqMediaType: Eq[MediaType] = Eq.fromUniversalEquals
+  implicit val showMediaType: Show[MediaType] = Show.fromToString
+  implicit val orderMediaType: Order[MediaType] = Order.by { mediaType =>
+    (mediaType.rawValue, mediaType.parameters)
+  }
 }

--- a/shared/src/main/scala/io/lemonlabs/uri/Path.scala
+++ b/shared/src/main/scala/io/lemonlabs/uri/Path.scala
@@ -1,5 +1,7 @@
 package io.lemonlabs.uri
 
+import cats.implicits._
+import cats.{Eq, Order, Show}
 import io.lemonlabs.uri.config.UriConfig
 import io.lemonlabs.uri.parsing.{UrlParser, UrnParser}
 
@@ -36,6 +38,10 @@ object Path {
 
   def unapply(path: Path): Option[Vector[String]] =
     Some(path.parts)
+
+  implicit val eqPath: Eq[Path] = Eq.fromUniversalEquals
+  implicit val showPath: Show[Path] = Show.fromToString
+  implicit val orderPath: Order[Path] = Order.by(_.toString())
 }
 
 object PathParts {
@@ -99,6 +105,10 @@ object UrlPath {
       case _         => RootlessPath(parts)
     }
   }
+
+  implicit val eqUrlPath: Eq[UrlPath] = Eq.fromUniversalEquals
+  implicit val showUrlPath: Show[UrlPath] = Show.fromToString
+  implicit val orderUrlPath: Order[UrlPath] = Order.by(_.toString())
 }
 
 /**
@@ -114,6 +124,11 @@ sealed trait AbsoluteOrEmptyPath extends UrlPath {
 
   def toRootless: RootlessPath =
     RootlessPath(parts)
+}
+object AbsoluteOrEmptyPath {
+  implicit val eqAbsoluteOrEmptyPath: Eq[AbsoluteOrEmptyPath] = Eq.fromUniversalEquals
+  implicit val showAbsoluteOrEmptyPath: Show[AbsoluteOrEmptyPath] = Show.fromToString
+  implicit val orderAbsoluteOrEmptyPath: Order[AbsoluteOrEmptyPath] = Order.by(_.toString())
 }
 
 case object EmptyPath extends AbsoluteOrEmptyPath {
@@ -165,6 +180,10 @@ final case class RootlessPath(parts: Vector[String])(implicit val config: UriCon
 object RootlessPath {
   def fromParts(parts: String*)(implicit config: UriConfig = UriConfig.default): RootlessPath =
     new RootlessPath(parts.toVector)
+
+  implicit val eqRootlessPath: Eq[RootlessPath] = Eq.fromUniversalEquals
+  implicit val showRootlessPath: Show[RootlessPath] = Show.fromToString
+  implicit val orderRootlessPath: Order[RootlessPath] = Order.by(_.parts)
 }
 
 /**
@@ -192,6 +211,10 @@ final case class AbsolutePath(parts: Vector[String])(implicit val config: UriCon
 object AbsolutePath {
   def fromParts(parts: String*)(implicit config: UriConfig = UriConfig.default): AbsolutePath =
     new AbsolutePath(parts.toVector)
+
+  implicit val eqAbsolutePath: Eq[AbsolutePath] = Eq.fromUniversalEquals
+  implicit val showAbsolutePath: Show[AbsolutePath] = Show.fromToString
+  implicit val orderAbsolutePath: Order[AbsolutePath] = Order.by(_.parts)
 }
 
 final case class UrnPath(nid: String, nss: String)(implicit val config: UriConfig = UriConfig.default) extends Path {
@@ -218,4 +241,10 @@ object UrnPath {
 
   def parse(s: CharSequence)(implicit config: UriConfig = UriConfig.default): UrnPath =
     parseTry(s).get
+
+  implicit val eqUrnPath: Eq[UrnPath] = Eq.fromUniversalEquals
+  implicit val showUrnPath: Show[UrnPath] = Show.fromToString
+  implicit val orderUrnPath: Order[UrnPath] = Order.by { path =>
+    (path.nid, path.nss)
+  }
 }

--- a/shared/src/main/scala/io/lemonlabs/uri/QueryString.scala
+++ b/shared/src/main/scala/io/lemonlabs/uri/QueryString.scala
@@ -1,5 +1,7 @@
 package io.lemonlabs.uri
 
+import cats.implicits._
+import cats.{Eq, Order, Show}
 import io.lemonlabs.uri.config.{All, ExcludeNones, UriConfig}
 import io.lemonlabs.uri.parsing.UrlParser
 
@@ -281,7 +283,7 @@ case class QueryString(params: Vector[(String, Option[String])])(implicit config
     }
 
     if (paramsAsString.isEmpty) ""
-    else "?" + paramsAsString.mkString("&")
+    else paramsAsString.mkString("&")
   }
 
   /**
@@ -318,4 +320,8 @@ object QueryString {
 
   def parse(s: CharSequence)(implicit config: UriConfig = UriConfig.default): QueryString =
     parseTry(s).get
+
+  implicit val eqQueryString: Eq[QueryString] = Eq.fromUniversalEquals
+  implicit val showQueryString: Show[QueryString] = Show.fromToString
+  implicit val orderQueryString: Order[QueryString] = Order.by(_.params)
 }

--- a/shared/src/test/scala/io/lemonlabs/uri/CatsLawTests.scala
+++ b/shared/src/test/scala/io/lemonlabs/uri/CatsLawTests.scala
@@ -1,0 +1,46 @@
+package io.lemonlabs.uri
+
+import cats.kernel.laws.discipline.OrderTests
+import org.scalatest.FunSuite
+import org.scalatestplus.scalacheck.Checkers
+import org.typelevel.discipline.Laws
+
+import cats.implicits._
+
+class CatsLawTests extends FunSuite with Checkers with UriScalaCheckGenerators {
+
+  // When upgrading to scalatest 3.1.0, this should come from discipline-scalatest
+  def checkAll(name: String, ruleSet: Laws#RuleSet): Unit = {
+    for ((id, prop) <- ruleSet.all.properties)
+      registerTest(s"$name.$id") {
+        check(prop)
+      }
+  }
+
+  // Note: OrderTests also run EqTests, so no need to also kick off EqTests here
+  checkAll("Uri.OrderTests", OrderTests[Uri].order)
+  checkAll("Url.OrderTests", OrderTests[Url].order)
+  checkAll("RelativeUrl.OrderTests", OrderTests[RelativeUrl].order)
+  checkAll("UrlWithAuthority.OrderTests", OrderTests[UrlWithAuthority].order)
+  checkAll("ProtocolRelativeUrl.OrderTests", OrderTests[ProtocolRelativeUrl].order)
+  checkAll("AbsoluteUrl.OrderTests", OrderTests[AbsoluteUrl].order)
+  checkAll("UrlWithoutAuthority.OrderTests", OrderTests[UrlWithoutAuthority].order)
+  checkAll("SimpleUrlWithoutAuthority.OrderTests", OrderTests[SimpleUrlWithoutAuthority].order)
+  checkAll("DataUrl.OrderTests", OrderTests[DataUrl].order)
+  checkAll("Urn.OrderTests", OrderTests[Urn].order)
+  checkAll("Authority.OrderTests", OrderTests[Authority].order)
+  checkAll("UserInfo.OrderTests", OrderTests[UserInfo].order)
+  checkAll("Host.OrderTests", OrderTests[Host].order)
+  checkAll("DomainName.OrderTests", OrderTests[DomainName].order)
+  checkAll("IpV4.OrderTests", OrderTests[IpV4].order)
+  checkAll("IpV6.OrderTests", OrderTests[IpV6].order)
+  checkAll("MediaType.OrderTests", OrderTests[MediaType].order)
+  checkAll("Path.OrderTests", OrderTests[Path].order)
+  checkAll("UrlPath.OrderTests", OrderTests[UrlPath].order)
+  checkAll("AbsoluteOrEmptyPath.OrderTests", OrderTests[AbsoluteOrEmptyPath].order)
+  checkAll("RootlessPath.OrderTests", OrderTests[RootlessPath].order)
+  checkAll("AbsolutePath.OrderTests", OrderTests[AbsolutePath].order)
+  checkAll("UrnPath.OrderTests", OrderTests[UrnPath].order)
+  checkAll("QueryString.OrderTests", OrderTests[QueryString].order)
+
+}

--- a/shared/src/test/scala/io/lemonlabs/uri/CatsTests.scala
+++ b/shared/src/test/scala/io/lemonlabs/uri/CatsTests.scala
@@ -1,0 +1,444 @@
+package io.lemonlabs.uri
+
+import org.scalatest.{FlatSpec, Matchers}
+import cats.implicits._
+import cats.kernel.Comparison
+
+class CatsTests extends FlatSpec with Matchers {
+
+  trait CatsTestCase {
+    val convertToEqualizer = () // shadow ScalaTest
+  }
+
+  "Eq" should "be supported for Uri" in new CatsTestCase {
+    val uri = Uri.parse("https://typelevel.org/cats/")
+    val uri2: Uri = AbsoluteUrl.parse("https://typelevel.org/cats/")
+
+    (uri === uri2) should equal(true)
+  }
+
+  it should "be supported for Url" in new CatsTestCase {
+    val uri = Url.parse("https://typelevel.org/cats/")
+    val uri2: Url = AbsoluteUrl.parse("https://typelevel.org/cats/")
+
+    (uri === uri2) should equal(true)
+  }
+
+  it should "be supported for RelativeUrl" in new CatsTestCase {
+    val uri: Url = RelativeUrl.parse("/cats2/")
+    val uri2: Url = RelativeUrl.parse("/cats/")
+
+    (uri === uri2) should equal(false)
+  }
+
+  it should "be supported for UrlWithAuthority" in new CatsTestCase {
+    val uri = UrlWithAuthority.parse("https://typelevel.org/cats/")
+    val uri2: UrlWithAuthority = AbsoluteUrl.parse("https://typelevel.org/cats/")
+
+    (uri === uri2) should equal(true)
+  }
+
+  it should "be supported for ProtocolRelativeUrl" in new CatsTestCase {
+    val uri = ProtocolRelativeUrl.parse("//typelevel.org/cats/")
+    val uri2 = ProtocolRelativeUrl.parse("//typelevel.org/cats/?different=true")
+
+    (uri =!= uri2) should equal(true)
+  }
+
+  it should "be supported for AbsoluteUrl" in new CatsTestCase {
+    val uri = AbsoluteUrl.parse("https://typelevel.org/cats/")
+    val uri2 = AbsoluteUrl.parse("https://typelevel.org/cats/")
+
+    (uri === uri2) should equal(true)
+  }
+
+  it should "be supported for UrlWithoutAuthority" in new CatsTestCase {
+    val uri = UrlWithoutAuthority.parse("mailto:someone@somewhere.com")
+    val uri2 = UrlWithoutAuthority.parse("mailto:someoneelse@somewhereelse.com")
+
+    (uri === uri2) should equal(false)
+  }
+
+  it should "be supported for SimpleUrlWithoutAuthority" in new CatsTestCase {
+    val uri = SimpleUrlWithoutAuthority.parse("mailto:someone@somewhere.com")
+    val uri2 = SimpleUrlWithoutAuthority.parse("mailto:someone@somewhere.com")
+
+    (uri === uri2) should equal(true)
+  }
+
+  it should "be supported for DataUrl" in new CatsTestCase {
+    val uri = DataUrl.parse("data:,A%20brief%20note")
+    val uri2 = DataUrl.parse("data:,Another%20brief%20note")
+
+    (uri =!= uri2) should equal(true)
+  }
+
+  it should "be supported for Urn" in new CatsTestCase {
+    val uri = Urn.parse("urn:cats:1")
+    val uri2 = Urn.parse("urn:cats:2")
+
+    (uri =!= uri2) should equal(true)
+  }
+
+  it should "be supported for Authority" in new CatsTestCase {
+    val authority = Authority.parse("typelevel.org:443")
+    val authority2 = Authority.parse("typelevel.org:443")
+
+    (authority === authority2) should equal(true)
+  }
+
+  it should "be supported for UserInfo" in new CatsTestCase {
+    val userInfo = UserInfo("user", "password")
+    val userInfo2 = UserInfo("user", "password2")
+
+    (userInfo =!= userInfo2) should equal(true)
+  }
+
+  it should "be supported for Host" in new CatsTestCase {
+    val host = Host.parse("typelevel.org")
+    val host2 = Host.parse("typelevel.org")
+
+    (host =!= host2) should equal(false)
+  }
+
+  it should "be supported for DomainName" in new CatsTestCase {
+    val host = DomainName.parse("typelevel.org")
+    val host2 = DomainName.parse("www.typelevel.org")
+
+    (host =!= host2) should equal(true)
+  }
+
+  it should "be supported for Ipv4" in new CatsTestCase {
+    val host = IpV4.parse("8.8.8.8")
+    val host2 = IpV4.parse("8.8.8.8")
+
+    (host === host2) should equal(true)
+  }
+
+  it should "be supported for Ipv6" in new CatsTestCase {
+    val host = IpV6.parse("[1f4:0:0:1e::1]")
+    val host2 = IpV6.parse("[1f4:0:0:1e::1]")
+
+    (host === host2) should equal(true)
+  }
+
+  it should "be supported for MediaType" in new CatsTestCase {
+    val mediaType = MediaType("text/plain".some, Vector("charset" -> "utf8"))
+    val mediaType2 = MediaType("text/plain".some, Vector.empty)
+
+    (mediaType === mediaType2) should equal(false)
+  }
+
+  it should "be supported for Path" in new CatsTestCase {
+    val path = Path.parse("/cats/")
+    val path2 = Path.parse("/cats/")
+
+    (path === path2) should equal(true)
+  }
+
+  it should "be supported for UrlPath" in new CatsTestCase {
+    val path = UrlPath.parse("/cats/")
+    val path2 = UrlPath.parse("/cats/")
+
+    (path === path2) should equal(true)
+  }
+
+  it should "be supported for AbsoluteOrEmptyPath" in new CatsTestCase {
+    val path: AbsoluteOrEmptyPath = AbsolutePath.fromParts("cats")
+    val path2: AbsoluteOrEmptyPath = AbsolutePath.fromParts("cats")
+
+    (path === path2) should equal(true)
+  }
+
+  it should "be supported for RootlessPath" in new CatsTestCase {
+    val path = RootlessPath.fromParts("cats")
+    val path2 = RootlessPath.fromParts("cats2")
+
+    (path =!= path2) should equal(true)
+  }
+
+  it should "be supported for AbsolutePath" in new CatsTestCase {
+    val path = AbsolutePath.fromParts("cats")
+    val path2 = AbsolutePath.fromParts("cats")
+
+    (path === path2) should equal(true)
+  }
+
+  it should "be supported for UrnPath" in new CatsTestCase {
+    val path = UrnPath.parse("cats:1")
+    val path2 = UrnPath.parse("cats:2")
+
+    (path =!= path2) should equal(true)
+  }
+
+  it should "be supported for QueryString" in new CatsTestCase {
+    val qs = QueryString.parse("a=1&b=2")
+    val qs2 = QueryString.parse("a=1&b=2")
+
+    (qs === qs2) should equal(true)
+  }
+
+  "Show" should "be supported for Uri" in {
+    val uri = Uri.parse("https://typelevel.org/cats/")
+    uri.show should equal("https://typelevel.org/cats/")
+  }
+
+  it should "be supported for Url" in {
+    val uri = Url.parse("https://typelevel.org/cats/")
+    uri.show should equal("https://typelevel.org/cats/")
+  }
+
+  it should "be supported for RelativeUrl" in {
+    val uri: Url = RelativeUrl.parse("/cats2/")
+    uri.show should equal("/cats2/")
+  }
+
+  it should "be supported for UrlWithAuthority" in {
+    val uri = UrlWithAuthority.parse("https://typelevel.org/cats/")
+    uri.show should equal("https://typelevel.org/cats/")
+  }
+
+  it should "be supported for ProtocolRelativeUrl" in {
+    val uri = ProtocolRelativeUrl.parse("//typelevel.org/cats/")
+    uri.show should equal("//typelevel.org/cats/")
+  }
+
+  it should "be supported for AbsoluteUrl" in {
+    val uri = AbsoluteUrl.parse("https://typelevel.org/cats/")
+    uri.show should equal("https://typelevel.org/cats/")
+  }
+
+  it should "be supported for UrlWithoutAuthority" in {
+    val uri = UrlWithoutAuthority.parse("mailto:someone@somewhere.com")
+    uri.show should equal("mailto:someone@somewhere.com")
+  }
+
+  it should "be supported for SimpleUrlWithoutAuthority" in {
+    val uri = SimpleUrlWithoutAuthority.parse("mailto:someone@somewhere.com")
+    uri.show should equal("mailto:someone@somewhere.com")
+  }
+
+  it should "be supported for DataUrl" in {
+    val uri = DataUrl.parse("data:,A%20brief%20note")
+    uri.show should equal("data:,A%20brief%20note")
+  }
+
+  it should "be supported for Urn" in {
+    val uri = Urn.parse("urn:cats:1")
+    uri.show should equal("urn:cats:1")
+  }
+
+  it should "be supported for Authority" in {
+    val authority = Authority.parse("typelevel.org:443")
+    authority.show should equal("typelevel.org:443")
+  }
+
+  it should "be supported for UserInfo" in {
+    val userInfo = UserInfo("user", "password")
+    userInfo.show should equal("user:password")
+  }
+
+  it should "be supported for Host" in {
+    val host = Host.parse("typelevel.org")
+    host.show should equal("typelevel.org")
+  }
+
+  it should "be supported for DomainName" in {
+    val host = DomainName.parse("typelevel.org")
+    host.show should equal("typelevel.org")
+  }
+
+  it should "be supported for Ipv4" in {
+    val host = IpV4.parse("8.8.8.8")
+    host.show should equal("8.8.8.8")
+  }
+
+  it should "be supported for Ipv6" in {
+    val host = IpV6.parse("[1f4:0:0:1e::1]")
+    host.show should equal("[1f4:0:0:1e::1]")
+  }
+
+  it should "be supported for MediaType" in {
+    val mediaType = MediaType("text/plain".some, Vector("charset" -> "utf8"))
+    mediaType.show should equal("text/plain;charset=utf8")
+  }
+
+  it should "be supported for Path" in {
+    val path = Path.parse("/cats/")
+    path.show should equal("/cats/")
+  }
+
+  it should "be supported for UrlPath" in {
+    val path = UrlPath.parse("/cats/")
+    path.show should equal("/cats/")
+  }
+
+  it should "be supported for AbsoluteOrEmptyPath" in {
+    val path: AbsoluteOrEmptyPath = AbsolutePath.fromParts("cats")
+    path.show should equal("/cats")
+  }
+
+  it should "be supported for RootlessPath" in {
+    val path = RootlessPath.fromParts("cats")
+    path.show should equal("cats")
+  }
+
+  it should "be supported for AbsolutePath" in {
+    val path = AbsolutePath.fromParts("cats")
+    path.show should equal("/cats")
+  }
+
+  it should "be supported for UrnPath" in {
+    val path = UrnPath.parse("cats:1")
+    path.show should equal("cats:1")
+  }
+
+  it should "be supported for QueryString" in {
+    val qs = QueryString.parse("a=1&b=2")
+    qs.show should equal("a=1&b=2")
+  }
+
+  "Order" should "be supported for Uri" in new CatsTestCase {
+    val uri = Uri.parse("https://typelevel.org/cats2/")
+    val uri2: Uri = AbsoluteUrl.parse("https://typelevel.org/cats/")
+    (uri comparison uri2) should equal(Comparison.GreaterThan)
+  }
+
+  it should "be supported for Url" in new CatsTestCase {
+    val uri = Url.parse("https://typelevel.org/cats/")
+    val uri2: Url = AbsoluteUrl.parse("https://typelevel.org/cats/")
+    (uri comparison uri2) should equal(Comparison.EqualTo)
+  }
+
+  it should "be supported for RelativeUrl" in new CatsTestCase {
+    val uri: Url = RelativeUrl.parse("/cats2/")
+    val uri2: Url = RelativeUrl.parse("/cats/")
+    (uri comparison uri2) should equal(Comparison.GreaterThan)
+  }
+
+  it should "be supported for UrlWithAuthority" in new CatsTestCase {
+    val uri = UrlWithAuthority.parse("https://typelevel.org/cats/")
+    val uri2: UrlWithAuthority = AbsoluteUrl.parse("https://typelevel.org/cats/")
+    (uri comparison uri2) should equal(Comparison.EqualTo)
+  }
+
+  it should "be supported for ProtocolRelativeUrl" in new CatsTestCase {
+    val uri = ProtocolRelativeUrl.parse("//typelevel.org/cats/")
+    val uri2 = ProtocolRelativeUrl.parse("//typelevel.org/cats/?different=true")
+    (uri comparison uri2) should equal(Comparison.LessThan)
+  }
+
+  it should "be supported for AbsoluteUrl" in new CatsTestCase {
+    val uri = AbsoluteUrl.parse("https://typelevel.org/cats/")
+    val uri2 = AbsoluteUrl.parse("https://typelevel.org/cats/")
+    (uri comparison uri2) should equal(Comparison.EqualTo)
+  }
+
+  it should "be supported for UrlWithoutAuthority" in new CatsTestCase {
+    val uri = UrlWithoutAuthority.parse("mailto:someone@somewhere.com")
+    val uri2 = UrlWithoutAuthority.parse("mailto:someoneelse@somewhereelse.com")
+    (uri comparison uri2) should equal(Comparison.LessThan)
+  }
+
+  it should "be supported for SimpleUrlWithoutAuthority" in new CatsTestCase {
+    val uri = SimpleUrlWithoutAuthority.parse("mailto:someone@somewhere.com")
+    val uri2 = SimpleUrlWithoutAuthority.parse("mailto:someone@somewhere.com")
+    (uri comparison uri2) should equal(Comparison.EqualTo)
+  }
+
+  it should "be supported for DataUrl" in new CatsTestCase {
+    val uri = DataUrl.parse("data:text;,A%20brief%20note")
+    val uri2 = DataUrl.parse("data:text;base64,R0lGODdh")
+    (uri comparison uri2) should equal(Comparison.LessThan)
+  }
+
+  "Order" should "be supported for Urn" in new CatsTestCase {
+    val uri = Urn.parse("urn:cats:1")
+    val uri2 = Urn.parse("urn:cats:2")
+    (uri comparison uri2) should equal(Comparison.LessThan)
+  }
+
+  it should "be supported for Authority" in new CatsTestCase {
+    val authority = Authority.parse("typelevel.org:443")
+    val authority2 = Authority.parse("typelevel.org:443")
+    (authority comparison authority2) should equal(Comparison.EqualTo)
+  }
+
+  it should "be supported for UserInfo" in new CatsTestCase {
+    val userInfo = UserInfo("user", "password")
+    val userInfo2 = UserInfo("user", "password2")
+    (userInfo comparison userInfo2) should equal(Comparison.LessThan)
+  }
+
+  it should "be supported for Host" in new CatsTestCase {
+    val host = Host.parse("typelevel.org")
+    val host2 = Host.parse("typelevel.org")
+    (host comparison host2) should equal(Comparison.EqualTo)
+  }
+
+  it should "be supported for DomainName" in new CatsTestCase {
+    val host = DomainName.parse("typelevel.org")
+    val host2 = DomainName.parse("www.typelevel.org")
+    (host comparison host2) should equal(Comparison.LessThan)
+  }
+
+  it should "be supported for Ipv4" in new CatsTestCase {
+    val host = IpV4.parse("8.8.8.8")
+    val host2 = IpV4.parse("8.8.8.8")
+    (host comparison host2) should equal(Comparison.EqualTo)
+  }
+
+  it should "be supported for Ipv6" in new CatsTestCase {
+    val host = IpV6.parse("[1f4:0:0:1e::1]")
+    val host2 = IpV6.parse("[1f4:0:0:1e::1]")
+    (host comparison host2) should equal(Comparison.EqualTo)
+  }
+
+  it should "be supported for MediaType" in new CatsTestCase {
+    val mediaType = MediaType("text/plain".some, Vector("charset" -> "utf8"))
+    val mediaType2 = MediaType("text/plain".some, Vector.empty)
+    (mediaType comparison mediaType2) should equal(Comparison.GreaterThan)
+  }
+
+  it should "be supported for Path" in new CatsTestCase {
+    val path = Path.parse("/cats/")
+    val path2 = Path.parse("/cats/")
+    (path comparison path2) should equal(Comparison.EqualTo)
+  }
+
+  it should "be supported for UrlPath" in new CatsTestCase {
+    val path = UrlPath.parse("/cats/")
+    val path2 = UrlPath.parse("/cats/")
+    (path comparison path2) should equal(Comparison.EqualTo)
+  }
+
+  it should "be supported for AbsoluteOrEmptyPath" in new CatsTestCase {
+    val path: AbsoluteOrEmptyPath = AbsolutePath.fromParts("cats")
+    val path2: AbsoluteOrEmptyPath = AbsolutePath.fromParts("cats")
+    (path comparison path2) should equal(Comparison.EqualTo)
+  }
+
+  it should "be supported for RootlessPath" in new CatsTestCase {
+    val path = RootlessPath.fromParts("cats")
+    val path2 = RootlessPath.fromParts("cats2")
+    (path comparison path2) should equal(Comparison.LessThan)
+  }
+
+  it should "be supported for AbsolutePath" in new CatsTestCase {
+    val path = AbsolutePath.fromParts("cats")
+    val path2 = AbsolutePath.fromParts("cats")
+    (path comparison path2) should equal(Comparison.EqualTo)
+  }
+
+  it should "be supported for UrnPath" in new CatsTestCase {
+    val path = UrnPath.parse("cats:1")
+    val path2 = UrnPath.parse("cats:2")
+    (path comparison path2) should equal(Comparison.LessThan)
+  }
+
+  it should "be supported for QueryString" in new CatsTestCase {
+    val qs = QueryString.parse("a=1&b=2")
+    val qs2 = QueryString.parse("a=1&b=2")
+    (qs comparison qs2) should equal(Comparison.EqualTo)
+  }
+}

--- a/shared/src/test/scala/io/lemonlabs/uri/ParsingTests.scala
+++ b/shared/src/test/scala/io/lemonlabs/uri/ParsingTests.scala
@@ -303,12 +303,12 @@ class ParsingTests extends FlatSpec with Matchers {
 
   "A URL with userinfo" should "parse as an URL" in {
     val url = Url.parse("http://:@www.example.com")
-    url.toUrl.toAbsoluteUrl.userInfo should equal(UserInfo(Some(""), Some("")))
+    url.toUrl.toAbsoluteUrl.userInfo should equal(Some(UserInfo("", Some(""))))
   }
 
   "exotic/reserved characters in user info" should "be decoded" in {
-    val parsedUserInfo = UserInfo.parse("user%3A:p%40ssword%E2%87%94@")
-    parsedUserInfo.user should equal(Some("user:"))
+    val parsedUserInfo = UserInfo.parse("user%3A:p%40ssword%E2%87%94")
+    parsedUserInfo.user should equal("user:")
     parsedUserInfo.password should equal(Some("p@ssword⇔"))
   }
 

--- a/shared/src/test/scala/io/lemonlabs/uri/UriScalaCheckGenerators.scala
+++ b/shared/src/test/scala/io/lemonlabs/uri/UriScalaCheckGenerators.scala
@@ -1,0 +1,262 @@
+package io.lemonlabs.uri
+
+import java.util.Base64
+
+import cats.Show
+import io.lemonlabs.uri.encoding.PercentEncoder
+import org.scalacheck.{Arbitrary, Cogen, Gen}
+import cats.implicits._
+import org.scalacheck.Gen.{const, some}
+
+trait UriScalaCheckGenerators {
+
+  private val unicodeChar: Gen[Char] = Gen.frequency(
+    (9, Gen.asciiChar),
+    (1, Arbitrary.arbChar.arbitrary)
+  )
+
+  private val genDelimChar: Gen[Char] =
+    Gen.oneOf(":/?#[]@".toSeq)
+
+  private val subDelimChar: Gen[Char] =
+    Gen.oneOf("!$&'()*+,;=".toSeq)
+
+  private val reservedChar: Gen[Char] =
+    Gen.oneOf(genDelimChar, subDelimChar)
+
+  private val percentEncodedChar: Gen[String] = {
+    val pe = PercentEncoder()
+    unicodeChar.map(pe.encodeChar)
+  }
+
+  private val unreservedChar: Gen[Char] = Gen.frequency(
+    (9, Gen.alphaNumChar),
+    (1, Gen.oneOf("-._~".toSeq))
+  )
+
+  private val pChar: Gen[String] = Gen.frequency(
+    (50, unreservedChar.map(_.toString)),
+    (1, percentEncodedChar),
+    (1, subDelimChar.map(_.toString)),
+    (1, Gen.oneOf(":", "@"))
+  )
+
+  private def strGen[T](charGen: Gen[T], min: Int = 0, max: Int = 10): Gen[String] =
+    Gen.chooseNum(min, max).flatMap { length =>
+      Gen.listOfN(length, charGen).map(_.mkString)
+    }
+
+  // format: off
+  private val randScheme: Gen[String] = Gen.oneOf(
+    "aaa", "aaas", "about", "acap", "acct", "acr", "adiumxtra", "afp", "afs", "aim", "apt", "attachment", "aw",
+    "amss", "barion", "beshare", "bitcoin", "blob", "bolo", "callto", "cap", "chrome", "chrome-extension",
+    "com-eventbrite-attendee", "cid", "coap", "coaps", "content", "crid", "cvs", "dab", "data", "dav", "dict",
+    "dlna-playsingle", "dlna-playcontainer", "dns", "dntp", "drm", "dtn", "dvb", "ed2k", "example", "facetime",
+    "fax", "feed", "file", "filesystem", "finger", "fish", "fm", "ftp", "geo", "gg", "git", "gizmoproject", "go",
+    "gopher", "gtalk", "h323", "hcp", "http", "https", "iax", "icap", "icon", "im", "imap", "info", "iotdisco",
+    "ipn", "ipp", "ipps", "irc", "irc6", "irc", "ircs", "irc", "iris", "iris.beep", "iris.xpc", "iris.xpcs",
+    "iris.lws", "itms", "jabber", "jar", "jms", "keyparc", "lastfm", "ldap", "ldaps", "ldap", "magnet",
+    "mailserver", "mailto", "maps", "market", "message", "mid", "mms", "modem", "ms-help", "ms-settings",
+    "ms-settings-airplanemode", "ms-settings-bluetooth", "ms-settings-camera", "ms-settings-cellular",
+    "ms-settings-cloudstorage", "ms-settings-emailandaccounts", "ms-settings-language", "ms-settings-location",
+    "ms-settings-lock", "ms-settings-nfctransactions", "ms-settings-notifications", "ms-settings-power",
+    "ms-settings-privacy", "ms-settings-proximity", "ms-settings-screenrotation", "ms-settings-wifi",
+    "ms-settings-workplace", "msnim", "msrp", "msrps", "mtqp", "mumble", "mupdate", "mvn", "news", "resource",
+    "nfs", "ni", "nih", "nntp", "notes", "oid", "opaquelocktoken", "pack", "palm", "paparazzi", "pkcs11",
+    "platform", "pop", "pres", "prospero", "proxy", "psyc", "query", "redis", "rediss", "reload", "res",
+    "resource", "rmi", "rsync", "rtmfp", "rtmp", "rtsp", "secondlife", "service", "session", "sftp", "sgn",
+    "shttp", "sieve", "sip", "sips", "sip", "skype", "smb", "sms", "citation needed", "snews", "snmp",
+    "soap.beep", "soap.beeps", "soldat", "spotify", "ssh", "steam", "stun", "stuns", "svn", "tag", "teamspeak",
+    "tel", "telnet", "tftp", "things", "thismessage", "tn3270", "tip", "turn", "turns", "tv", "udp", "unreal",
+    "urn", "ut2004", "vemmi", "ventrilo", "videotex", "view-source", "wais", "webcal", "ws", "wss", "wtai",
+    "wyciwyg", "xcon", "xcon-userid", "xfire", "xmlrpc.beep", "xmlrpc.beeps", "xmpp", "xri", "ymsgr", "z39.50",
+    "z39.50r", "z39.50s", "app", "doi", "javascript", "jdbc", "odbc", "stratum", "vnc", "web+abc"
+  )
+  // format: off
+
+  implicit val randIpV6:Arbitrary[IpV6] =  {
+    val piece = Gen.chooseNum(0, Char.MaxValue)
+    Arbitrary(Gen.zip(piece, piece, piece, piece, piece, piece, piece, piece).map {
+      case (a, b, c, d, e, f, g, h) => IpV6(a, b, c, d, e, f, g, h)
+    })
+  }
+
+  implicit val randIpV4: Arbitrary[IpV4] =  {
+    val octet = Gen.chooseNum(0, 255)
+    Arbitrary(Gen.zip(octet, octet, octet, octet).map {
+      case (a, b, c, d) => IpV4(a, b, c, d)
+    })
+  }
+
+  implicit val randDomainName: Arbitrary[DomainName] =  {
+    val chars: Gen[String] = Gen.frequency(
+      (50, unreservedChar.map(_.toString)),
+      (1, percentEncodedChar),
+      (1, subDelimChar.map(_.toString))
+    )
+    Arbitrary(strGen(chars, max = 15).map(DomainName.parse))
+  }
+
+  implicit val randHost: Arbitrary[Host] =
+    Arbitrary(Gen.oneOf(randDomainName.arbitrary, randIpV4.arbitrary, randIpV6.arbitrary))
+
+  implicit val randUserInfo:  Arbitrary[UserInfo] =  {
+    val userOrPass = strGen(Gen.frequency(
+                              (50, unreservedChar),
+                              (1, percentEncodedChar),
+                              (1, subDelimChar)
+                            ),
+                            max = 15)
+    val gen = for {
+      user <- userOrPass
+      pass <- Gen.frequency(9 -> const(None), 1 -> some(userOrPass))
+    } yield UserInfo(user, pass)
+    Arbitrary(gen)
+  }
+
+  implicit val randAuthority: Arbitrary[Authority] = {
+    val gen = for {
+      userInfo <- Gen.option(randUserInfo.arbitrary)
+      host <- randHost.arbitrary
+      port <- Gen.frequency(
+        (1, Gen.some(Gen.chooseNum(0, 65535))),
+        (9, Gen.const(None))
+      )
+    } yield Authority(userInfo, host, port)
+    Arbitrary(gen)
+  }
+
+  implicit val randMediaType: Arbitrary[MediaType] = {
+    val restrictedName = strGen(
+      Gen.frequency(
+        (9, Gen.alphaNumChar),
+        (1, Gen.oneOf("!#$&-^_.+"))
+      ))
+    val parameter = Gen.oneOf(restrictedName.map(_ -> ""), Gen.zip(restrictedName, restrictedName))
+    val gen = for {
+      value <- Gen.oneOf(
+        Gen.const(None),
+        Gen.some(restrictedName), // Just type
+        Gen.listOfN(2, restrictedName).map(parts => Some(parts.mkString("/"))) // Type and subtype
+      )
+      params <- Gen.chooseNum(0, 3).flatMap(size => Gen.listOfN(size, parameter).map(_.toVector))
+    } yield MediaType(value, params)
+    Arbitrary(gen)
+  }
+
+  private val randSegments: Gen[List[String]] = for {
+    size <- Gen.chooseNum(0, 5)
+    elems <- Gen.listOfN(size, strGen(pChar))
+  } yield elems
+
+  implicit val randUrnPath: Arbitrary[UrnPath] = {
+    val gen = for {
+      nss <- strGen(pChar)
+      nid <- strGen(pChar)
+    } yield UrnPath(nid, nss)
+    Arbitrary(gen)
+  }
+
+  implicit val randAbsolutePath: Arbitrary[AbsolutePath] =
+    Arbitrary(randSegments.map(parts => AbsolutePath(parts.toVector)))
+
+  implicit val randRootlessPath: Arbitrary[RootlessPath] =
+    Arbitrary(randSegments.map(parts => RootlessPath(parts.toVector)))
+
+  implicit val randAbsoluteOrEmptyPath: Arbitrary[AbsoluteOrEmptyPath] =
+    Arbitrary(Gen.oneOf(randAbsolutePath.arbitrary, Gen.const(EmptyPath)))
+
+  implicit val randUrlPath:  Arbitrary[UrlPath] =
+    Arbitrary(Gen.oneOf(randAbsoluteOrEmptyPath.arbitrary, randRootlessPath.arbitrary))
+
+  implicit val randPath:  Arbitrary[Path] =
+    Arbitrary(Gen.oneOf(randUrlPath.arbitrary, randUrnPath.arbitrary))
+
+  private val randQueryStringParam: Gen[(String, Option[String])] =  {
+    val chars = Gen.frequency(
+      (20, pChar),
+      (1, Gen.oneOf("/", "?"))
+    )
+    for {
+      key <- strGen(chars)
+      value <- Gen.some(strGen(chars, max = 30))
+    } yield (key, value)
+  }
+
+  implicit val randQueryString: Arbitrary[QueryString] = {
+    val gen = for {
+      numParams <- Gen.chooseNum(0, 5)
+      params <- Gen.listOfN(numParams, randQueryStringParam)
+    } yield QueryString(params.toVector)
+    Arbitrary(gen)
+  }
+
+  private val randFragment: Gen[Option[String]] = {
+    val chars = Gen.frequency(
+      (20, pChar),
+      (1, Gen.oneOf("/", "?"))
+    )
+    Gen.frequency(
+      (8, Gen.const(None)),
+      (2, Gen.some(strGen(chars)))
+    )
+  }
+
+  implicit val randDataUrl: Arbitrary[DataUrl] =  {
+    val base64Bytes = strGen(unicodeChar, max = 30).map(s => Base64.getEncoder.withoutPadding().encode(s.getBytes()))
+    val plainBytes = strGen(unicodeChar, max = 30).map(_.getBytes)
+    Arbitrary(Gen.oneOf(
+      Gen.zip(randMediaType.arbitrary, Gen.const(true), base64Bytes).map((DataUrl.apply _).tupled),
+      Gen.zip(randMediaType.arbitrary, Gen.const(false), plainBytes).map((DataUrl.apply _).tupled)
+    ))
+  }
+
+  implicit val randSimpleUrlWithoutAuthority: Arbitrary[SimpleUrlWithoutAuthority] =
+    Arbitrary(Gen.zip(randScheme, randUrlPath.arbitrary, randQueryString.arbitrary, randFragment).map((SimpleUrlWithoutAuthority.apply _).tupled))
+
+  implicit val randUrlWithoutAuthority: Arbitrary[UrlWithoutAuthority] =
+    Arbitrary(Gen.oneOf(randSimpleUrlWithoutAuthority.arbitrary, randDataUrl.arbitrary))
+
+  implicit val randAbsoluteUrl: Arbitrary[AbsoluteUrl] =
+    Arbitrary(Gen.zip(randScheme, randAuthority.arbitrary, randAbsoluteOrEmptyPath.arbitrary, randQueryString.arbitrary, randFragment).map((AbsoluteUrl.apply _).tupled))
+
+  implicit val randProtocolRelativeUrl: Arbitrary[ProtocolRelativeUrl] =
+    Arbitrary(Gen.zip(randAuthority.arbitrary, randAbsoluteOrEmptyPath.arbitrary, randQueryString.arbitrary, randFragment).map((ProtocolRelativeUrl.apply _).tupled))
+
+  implicit val randUrlWithAuthority: Arbitrary[UrlWithAuthority] =
+    Arbitrary(Gen.oneOf(randAbsoluteUrl.arbitrary, randProtocolRelativeUrl.arbitrary))
+
+  implicit val randRelativeUrl: Arbitrary[RelativeUrl] =
+    Arbitrary(Gen.zip(randUrlPath.arbitrary, randQueryString.arbitrary, randFragment).map((RelativeUrl.apply _).tupled))
+
+  implicit val randUrl: Arbitrary[Url] =
+    Arbitrary(Gen.oneOf(randDataUrl.arbitrary, randSimpleUrlWithoutAuthority.arbitrary, randAbsoluteUrl.arbitrary, randProtocolRelativeUrl.arbitrary, randRelativeUrl.arbitrary))
+
+  implicit val randUrn: Arbitrary[Urn] =
+    Arbitrary(randUrnPath.arbitrary.map(Urn.apply))
+
+  implicit val randUri: Arbitrary[Uri] = Arbitrary(
+    Gen.oneOf(randUrn.arbitrary, randDataUrl.arbitrary, randSimpleUrlWithoutAuthority.arbitrary, randAbsoluteUrl.arbitrary, randProtocolRelativeUrl.arbitrary, randRelativeUrl.arbitrary)
+  )
+
+  implicit def uriCogen[T <: Uri: Show]: Cogen[T] =
+    Cogen[String].contramap(_.show)
+
+  implicit def hostCogen[T <: Host: Show]: Cogen[T] =
+    Cogen[String].contramap(_.show)
+
+  implicit def pathCogen[T <: Path: Show]: Cogen[T] =
+    Cogen[String].contramap(_.show)
+
+  implicit val userInfoCogen: Cogen[UserInfo] =
+    Cogen[String].contramap(_.show)
+
+  implicit val queryStringCogen: Cogen[QueryString] =
+    Cogen[String].contramap(_.show)
+
+  implicit val authorityCogen: Cogen[Authority] =
+    Cogen[String].contramap(_.show)
+
+  implicit val mediaTypeCogen: Cogen[MediaType] =
+    Cogen[String].contramap(_.show)
+}


### PR DESCRIPTION
Provide type class instances of `cats.Eq`, `cats.Show` and `cats.Order` for all the scala-uri types.
