### PR TITLE
Adds Contravariant instances to the Fragment, PathPart, QueryValue, QueryKey, TraversableParams

### DIFF
--- a/shared/src/main/scala/io/lemonlabs/uri/typesafe/Fragment.scala
+++ b/shared/src/main/scala/io/lemonlabs/uri/typesafe/Fragment.scala
@@ -1,6 +1,9 @@
 package io.lemonlabs.uri.typesafe
 
+import cats.{Contravariant, Eq}
 import simulacrum.typeclass
+import cats.syntax.contravariant._
+
 import scala.language.implicitConversions
 
 @typeclass trait Fragment[A] {
@@ -9,11 +12,24 @@ import scala.language.implicitConversions
 
 object Fragment extends FragmentInstances
 
-trait FragmentInstances1 {
+sealed trait FragmentInstances2 {
+  implicit val contravariant: Contravariant[Fragment] = new Contravariant[Fragment] {
+    def contramap[A, B](fa: Fragment[A])(f: B => A): Fragment[B] = b => fa.fragment(f(b))
+  }
+}
+
+sealed trait FragmentInstances1 extends FragmentInstances2 {
   implicit val stringFragment: Fragment[String] = a => a
+  implicit final val booleanQueryValue: Fragment[Boolean] = stringFragment.contramap(_.toString)
+  implicit final val charQueryValue: Fragment[Char] = stringFragment.contramap(_.toString)
+  implicit final val intQueryValue: Fragment[Int] = stringFragment.contramap(_.toString)
+  implicit final val longQueryValue: Fragment[Long] = stringFragment.contramap(_.toString)
+  implicit final val floatQueryValue: Fragment[Float] = stringFragment.contramap(_.toString)
+  implicit final val doubleQueryValue: Fragment[Double] = stringFragment.contramap(_.toString)
+  implicit final val uuidQueryValue: Fragment[java.util.UUID] = stringFragment.contramap(_.toString)
   implicit val noneFragment: Fragment[None.type] = _ => ""
 }
 
-trait FragmentInstances extends FragmentInstances1 {
+sealed trait FragmentInstances extends FragmentInstances1 {
   implicit def optionFragment[A: Fragment]: Fragment[Option[A]] = _.map(Fragment[A].fragment).getOrElse("")
 }

--- a/shared/src/main/scala/io/lemonlabs/uri/typesafe/PathPart.scala
+++ b/shared/src/main/scala/io/lemonlabs/uri/typesafe/PathPart.scala
@@ -1,6 +1,11 @@
 package io.lemonlabs.uri.typesafe
 
+import java.util.UUID
+
+import cats.Contravariant
+import cats.syntax.contravariant._
 import simulacrum.typeclass
+
 import scala.language.implicitConversions
 
 @typeclass trait PathPart[A] {
@@ -9,10 +14,23 @@ import scala.language.implicitConversions
 
 object PathPart extends PathPartInstances
 
-trait PathPartInstances1 {
-  implicit val stringPathPart: PathPart[String] = a => a
+sealed trait PathPartInstances2 {
+  implicit val contravariant: Contravariant[PathPart] = new Contravariant[PathPart] {
+    def contramap[A, B](fa: PathPart[A])(f: B => A): PathPart[B] = b => fa.path(f(b))
+  }
 }
 
-trait PathPartInstances extends PathPartInstances1 {
+sealed trait PathPartInstances1 extends PathPartInstances2 {
+  implicit val stringPathPart: PathPart[String] = a => a
+  implicit val booleanPathPart: PathPart[Boolean] = stringPathPart.contramap(_.toString)
+  implicit val charPathPart: PathPart[Char] = stringPathPart.contramap(_.toString)
+  implicit val intPathPart: PathPart[Int] = stringPathPart.contramap(_.toString)
+  implicit val longPathPart: PathPart[Long] = stringPathPart.contramap(_.toString)
+  implicit val floatPathPart: PathPart[Float] = stringPathPart.contramap(_.toString)
+  implicit val doublePathPart: PathPart[Double] = stringPathPart.contramap(_.toString)
+  implicit val uuidPathPart: PathPart[UUID] = stringPathPart.contramap(_.toString)
+}
+
+sealed trait PathPartInstances extends PathPartInstances1 {
   implicit def optionPathPart[A: PathPart]: PathPart[Option[A]] = a => a.map(PathPart[A].path).getOrElse("")
 }

--- a/shared/src/test/scala/io/lemonlabs/uri/CatsLawTests.scala
+++ b/shared/src/test/scala/io/lemonlabs/uri/CatsLawTests.scala
@@ -4,8 +4,11 @@ import cats.kernel.laws.discipline.OrderTests
 import org.scalatest.FunSuite
 import org.scalatestplus.scalacheck.Checkers
 import org.typelevel.discipline.Laws
-
 import cats.implicits._
+import cats.Eq
+import cats.laws.discipline.eq._
+import cats.laws.discipline.{ContravariantTests, ExhaustiveCheck}
+import io.lemonlabs.uri.typesafe.{Fragment, PathPart, QueryKey, QueryValue, TraversableParams}
 
 class CatsLawTests extends FunSuite with Checkers with UriScalaCheckGenerators {
   // When upgrading to scalatest 3.1.0, this should come from discipline-scalatest
@@ -15,6 +18,21 @@ class CatsLawTests extends FunSuite with Checkers with UriScalaCheckGenerators {
         check(prop)
       }
   }
+
+  implicit def eqFragment[A: ExhaustiveCheck]: Eq[Fragment[A]] =
+    Eq.by[Fragment[A], A => String](_.fragment)
+
+  implicit def eqPathPart[A: ExhaustiveCheck]: Eq[PathPart[A]] =
+    Eq.by[PathPart[A], A => String](_.path)
+
+  implicit def eqQueryValue[A: ExhaustiveCheck]: Eq[QueryValue[A]] =
+    Eq.by[QueryValue[A], A => Option[String]](_.queryValue)
+
+  implicit def eqQueryKey[A: ExhaustiveCheck]: Eq[QueryKey[A]] =
+    Eq.by[QueryKey[A], A => String](_.queryKey)
+
+  implicit def eqTraversableParams[A: ExhaustiveCheck]: Eq[TraversableParams[A]] =
+    Eq.by[TraversableParams[A], A => List[(String, Option[String])]](_.toSeq)
 
   // Note: OrderTests also run EqTests, so no need to also kick off EqTests here
   checkAll("Uri.OrderTests", OrderTests[Uri].order)
@@ -41,4 +59,12 @@ class CatsLawTests extends FunSuite with Checkers with UriScalaCheckGenerators {
   checkAll("AbsolutePath.OrderTests", OrderTests[AbsolutePath].order)
   checkAll("UrnPath.OrderTests", OrderTests[UrnPath].order)
   checkAll("QueryString.OrderTests", OrderTests[QueryString].order)
+  checkAll("Fragment.Contravariant", ContravariantTests[Fragment].contravariant[Boolean, Boolean, Boolean])
+  checkAll("PathPart.Contravariant", ContravariantTests[PathPart].contravariant[Boolean, Boolean, Boolean])
+  checkAll("QueryValue.Contravariant", ContravariantTests[QueryValue].contravariant[Boolean, Boolean, Boolean])
+  checkAll("QueryKey.Contravariant", ContravariantTests[QueryKey].contravariant[Boolean, Boolean, Boolean])
+  checkAll(
+    "TraversableParams.Contravariant",
+    ContravariantTests[TraversableParams].contravariant[Boolean, Boolean, Boolean]
+  )
 }

--- a/shared/src/test/scala/io/lemonlabs/uri/UriScalaCheckGenerators.scala
+++ b/shared/src/test/scala/io/lemonlabs/uri/UriScalaCheckGenerators.scala
@@ -6,6 +6,7 @@ import cats.Show
 import io.lemonlabs.uri.encoding.PercentEncoder
 import org.scalacheck.{Arbitrary, Cogen, Gen}
 import cats.implicits._
+import io.lemonlabs.uri.typesafe.{Fragment, PathPart, QueryKey, QueryValue, TraversableParams}
 import org.scalacheck.Gen.{const, some}
 
 trait UriScalaCheckGenerators {
@@ -237,6 +238,13 @@ trait UriScalaCheckGenerators {
   implicit val randUri: Arbitrary[Uri] = Arbitrary(
     Gen.oneOf(randUrn.arbitrary, randDataUrl.arbitrary, randSimpleUrlWithoutAuthority.arbitrary, randAbsoluteUrl.arbitrary, randProtocolRelativeUrl.arbitrary, randRelativeUrl.arbitrary)
   )
+
+  implicit def arbitraryFragment[A: Cogen]: Arbitrary[Fragment[A]] = Arbitrary(implicitly[Arbitrary[A => String]].arbitrary.map(f => f(_)))
+  implicit def arbitraryPathPart[A: Cogen]: Arbitrary[PathPart[A]] = Arbitrary(implicitly[Arbitrary[A => String]].arbitrary.map(f => f(_)))
+  implicit def arbitraryQueryValue[A: Cogen]: Arbitrary[QueryValue[A]] = Arbitrary(implicitly[Arbitrary[A => Option[String]]].arbitrary.map(f => f(_)))
+  implicit def arbitraryQueryKey[A: Cogen]: Arbitrary[QueryKey[A]] = Arbitrary(implicitly[Arbitrary[A => String]].arbitrary.map(f => f(_)))
+  implicit def arbitraryTraversableParams[A: Cogen]: Arbitrary[TraversableParams[A]] =
+    Arbitrary(implicitly[Arbitrary[A => List[(String, Option[String])]]].arbitrary.map(f => f(_)))
 
   implicit def uriCogen[T <: Uri: Show]: Cogen[T] =
     Cogen[String].contramap(_.show)


### PR DESCRIPTION
Apart from that unfortunately few breaking changes were introduced:

* multiple traits were tagged sealed
* `TraversableParams.toSeq` now returns `List`