### PR TITLE
Add config for scalafix-simulacrum

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,3 +12,5 @@ addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.7.0")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.0")
 
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.2")
+
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.17")

--- a/shared/src/main/scala/io/lemonlabs/uri/typesafe/Fragment.scala
+++ b/shared/src/main/scala/io/lemonlabs/uri/typesafe/Fragment.scala
@@ -4,13 +4,58 @@ import cats.Contravariant
 import simulacrum.typeclass
 
 import scala.language.implicitConversions
+import scala.annotation.implicitNotFound
 
-@typeclass trait Fragment[A] { self =>
+@implicitNotFound("Could not find an instance of Fragment for ${A}")
+@typeclass trait Fragment[A] extends Serializable { self =>
   def fragment(a: A): Option[String]
   def contramap[B](f: B => A): Fragment[B] = (b: B) => self.fragment(f(b))
 }
 
-object Fragment extends FragmentInstances
+object Fragment extends FragmentInstances {
+  /* ======================================================================== */
+  /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
+  /* ======================================================================== */
+
+  /**
+    * Summon an instance of [[Fragment]] for `A`.
+    */
+  @inline def apply[A](implicit instance: Fragment[A]): Fragment[A] = instance
+
+  object ops {
+    implicit def toAllFragmentOps[A](target: A)(implicit tc: Fragment[A]): AllOps[A] {
+      type TypeClassType = Fragment[A]
+    } =
+      new AllOps[A] {
+        type TypeClassType = Fragment[A]
+        val self: A = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
+  trait Ops[A] extends Serializable {
+    type TypeClassType <: Fragment[A]
+    def self: A
+    val typeClassInstance: TypeClassType
+    def fragment: Option[String] = typeClassInstance.fragment(self)
+  }
+  trait AllOps[A] extends Ops[A]
+  trait ToFragmentOps extends Serializable {
+    implicit def toFragmentOps[A](target: A)(implicit tc: Fragment[A]): Ops[A] {
+      type TypeClassType = Fragment[A]
+    } =
+      new Ops[A] {
+        type TypeClassType = Fragment[A]
+        val self: A = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
+  object nonInheritedOps extends ToFragmentOps
+
+  /* ======================================================================== */
+  /* END OF SIMULACRUM-MANAGED CODE                                           */
+  /* ======================================================================== */
+
+}
 
 sealed trait FragmentInstances2 {
   implicit val contravariant: Contravariant[Fragment] = new Contravariant[Fragment] {

--- a/shared/src/main/scala/io/lemonlabs/uri/typesafe/PathPart.scala
+++ b/shared/src/main/scala/io/lemonlabs/uri/typesafe/PathPart.scala
@@ -9,13 +9,59 @@ import shapeless.labelled._
 import simulacrum.typeclass
 
 import scala.language.implicitConversions
+import scala.annotation.implicitNotFound
 
-@typeclass trait PathPart[-A] {
+@implicitNotFound("Could not find an instance of PathPart for ${A}")
+@typeclass trait PathPart[-A] extends Serializable {
   def path(a: A): String
   def splitPath(a: A): Seq[String] = path(a).split('/').toSeq
 }
 
-object PathPart extends PathPartInstances
+object PathPart extends PathPartInstances {
+  /* ======================================================================== */
+  /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
+  /* ======================================================================== */
+
+  /**
+    * Summon an instance of [[PathPart]] for `A`.
+    */
+  @inline def apply[A](implicit instance: PathPart[A]): PathPart[A] = instance
+
+  object ops {
+    implicit def toAllPathPartOps[A](target: A)(implicit tc: PathPart[A]): AllOps[A] {
+      type TypeClassType = PathPart[A]
+    } =
+      new AllOps[A] {
+        type TypeClassType = PathPart[A]
+        val self: A = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
+  trait Ops[A] extends Serializable {
+    type TypeClassType <: PathPart[A]
+    def self: A
+    val typeClassInstance: TypeClassType
+    def path: String = typeClassInstance.path(self)
+    def splitPath: Seq[String] = typeClassInstance.splitPath(self)
+  }
+  trait AllOps[A] extends Ops[A]
+  trait ToPathPartOps extends Serializable {
+    implicit def toPathPartOps[A](target: A)(implicit tc: PathPart[A]): Ops[A] {
+      type TypeClassType = PathPart[A]
+    } =
+      new Ops[A] {
+        type TypeClassType = PathPart[A]
+        val self: A = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
+  object nonInheritedOps extends ToPathPartOps
+
+  /* ======================================================================== */
+  /* END OF SIMULACRUM-MANAGED CODE                                           */
+  /* ======================================================================== */
+
+}
 
 sealed trait PathPartInstances2 {
   implicit val contravariant: Contravariant[PathPart] = new Contravariant[PathPart] {
@@ -55,7 +101,8 @@ sealed trait TraversablePathPartsInstances {
     (ax: List[A]) => ax.flatMap(tc.splitPath)
 }
 
-@typeclass trait TraversablePathParts[A] {
+@implicitNotFound("Could not find an instance of TraversablePathParts for ${A}")
+@typeclass trait TraversablePathParts[A] extends Serializable {
   def toSeq(a: A): Seq[String]
   def toVector(a: A): Vector[String] =
     toSeq(a).toVector
@@ -85,4 +132,48 @@ object TraversablePathParts extends TraversablePathPartsInstances {
 
   def product[A, R <: HList](implicit gen: Generic.Aux[A, R], R: TraversablePathParts[R]): TraversablePathParts[A] =
     (a: A) => R.toSeq(gen.to(a))
+
+  /* ======================================================================== */
+  /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
+  /* ======================================================================== */
+
+  /**
+    * Summon an instance of [[TraversablePathParts]] for `A`.
+    */
+  @inline def apply[A](implicit instance: TraversablePathParts[A]): TraversablePathParts[A] = instance
+
+  object ops {
+    implicit def toAllTraversablePathPartsOps[A](target: A)(implicit tc: TraversablePathParts[A]): AllOps[A] {
+      type TypeClassType = TraversablePathParts[A]
+    } =
+      new AllOps[A] {
+        type TypeClassType = TraversablePathParts[A]
+        val self: A = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
+  trait Ops[A] extends Serializable {
+    type TypeClassType <: TraversablePathParts[A]
+    def self: A
+    val typeClassInstance: TypeClassType
+    def toSeq: Seq[String] = typeClassInstance.toSeq(self)
+    def toVector: Vector[String] = typeClassInstance.toVector(self)
+  }
+  trait AllOps[A] extends Ops[A]
+  trait ToTraversablePathPartsOps extends Serializable {
+    implicit def toTraversablePathPartsOps[A](target: A)(implicit tc: TraversablePathParts[A]): Ops[A] {
+      type TypeClassType = TraversablePathParts[A]
+    } =
+      new Ops[A] {
+        type TypeClassType = TraversablePathParts[A]
+        val self: A = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
+  object nonInheritedOps extends ToTraversablePathPartsOps
+
+  /* ======================================================================== */
+  /* END OF SIMULACRUM-MANAGED CODE                                           */
+  /* ======================================================================== */
+
 }

--- a/shared/src/main/scala/io/lemonlabs/uri/typesafe/QueryKeyValue.scala
+++ b/shared/src/main/scala/io/lemonlabs/uri/typesafe/QueryKeyValue.scala
@@ -9,12 +9,57 @@ import shapeless.ops.hlist.ToList
 import simulacrum.typeclass
 
 import scala.language.implicitConversions
+import scala.annotation.implicitNotFound
 
-@typeclass trait QueryKey[A] {
+@implicitNotFound("Could not find an instance of QueryKey for ${A}")
+@typeclass trait QueryKey[A] extends Serializable {
   def queryKey(a: A): String
 }
 
-object QueryKey extends QueryKeyInstances
+object QueryKey extends QueryKeyInstances {
+  /* ======================================================================== */
+  /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
+  /* ======================================================================== */
+
+  /**
+    * Summon an instance of [[QueryKey]] for `A`.
+    */
+  @inline def apply[A](implicit instance: QueryKey[A]): QueryKey[A] = instance
+
+  object ops {
+    implicit def toAllQueryKeyOps[A](target: A)(implicit tc: QueryKey[A]): AllOps[A] {
+      type TypeClassType = QueryKey[A]
+    } =
+      new AllOps[A] {
+        type TypeClassType = QueryKey[A]
+        val self: A = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
+  trait Ops[A] extends Serializable {
+    type TypeClassType <: QueryKey[A]
+    def self: A
+    val typeClassInstance: TypeClassType
+    def queryKey: String = typeClassInstance.queryKey(self)
+  }
+  trait AllOps[A] extends Ops[A]
+  trait ToQueryKeyOps extends Serializable {
+    implicit def toQueryKeyOps[A](target: A)(implicit tc: QueryKey[A]): Ops[A] {
+      type TypeClassType = QueryKey[A]
+    } =
+      new Ops[A] {
+        type TypeClassType = QueryKey[A]
+        val self: A = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
+  object nonInheritedOps extends ToQueryKeyOps
+
+  /* ======================================================================== */
+  /* END OF SIMULACRUM-MANAGED CODE                                           */
+  /* ======================================================================== */
+
+}
 
 sealed trait QueryKeyInstances1 {
   implicit val contravariant: Contravariant[QueryKey] = new Contravariant[QueryKey] {
@@ -33,7 +78,8 @@ sealed trait QueryKeyInstances extends QueryKeyInstances1 {
   implicit final val uuidQueryValue: QueryKey[java.util.UUID] = stringQueryKey.contramap(_.toString)
 }
 
-@typeclass trait QueryValue[-A] { self =>
+@implicitNotFound("Could not find an instance of QueryValue for ${A}")
+@typeclass trait QueryValue[-A] extends Serializable { self =>
   def queryValue(a: A): Option[String]
 }
 
@@ -46,6 +92,49 @@ object QueryValue extends QueryValueInstances {
     )(implicit gen: Generic.Aux[A, C], reify: Reify.Aux[C, R], toList: ToList[R, A]): QueryValue[A] =
       a => toList(reify()).iterator.map(x => x -> key(x)).toMap.get(a)
   }
+
+  /* ======================================================================== */
+  /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
+  /* ======================================================================== */
+
+  /**
+    * Summon an instance of [[QueryValue]] for `A`.
+    */
+  @inline def apply[A](implicit instance: QueryValue[A]): QueryValue[A] = instance
+
+  object ops {
+    implicit def toAllQueryValueOps[A](target: A)(implicit tc: QueryValue[A]): AllOps[A] {
+      type TypeClassType = QueryValue[A]
+    } =
+      new AllOps[A] {
+        type TypeClassType = QueryValue[A]
+        val self: A = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
+  trait Ops[A] extends Serializable {
+    type TypeClassType <: QueryValue[A]
+    def self: A
+    val typeClassInstance: TypeClassType
+    def queryValue: Option[String] = typeClassInstance.queryValue(self)
+  }
+  trait AllOps[A] extends Ops[A]
+  trait ToQueryValueOps extends Serializable {
+    implicit def toQueryValueOps[A](target: A)(implicit tc: QueryValue[A]): Ops[A] {
+      type TypeClassType = QueryValue[A]
+    } =
+      new Ops[A] {
+        type TypeClassType = QueryValue[A]
+        val self: A = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
+  object nonInheritedOps extends ToQueryValueOps
+
+  /* ======================================================================== */
+  /* END OF SIMULACRUM-MANAGED CODE                                           */
+  /* ======================================================================== */
+
 }
 
 sealed trait QueryValueInstances2 {
@@ -70,7 +159,8 @@ sealed trait QueryValueInstances extends QueryValueInstances1 {
   implicit final def optionQueryValue[A: QueryValue]: QueryValue[Option[A]] = _.flatMap(QueryValue[A].queryValue)
 }
 
-@typeclass trait QueryKeyValue[A] {
+@implicitNotFound("Could not find an instance of QueryKeyValue for ${A}")
+@typeclass trait QueryKeyValue[A] extends Serializable {
   def queryKey(a: A): String
 
   def queryValue(a: A): Option[String]
@@ -85,6 +175,51 @@ object QueryKeyValue extends QueryKeyValueInstances {
       def queryKey(a: T): String = QueryKey[K].queryKey(toKey(a))
       def queryValue(a: T): Option[String] = QueryValue[V].queryValue(toValue(a))
     }
+
+  /* ======================================================================== */
+  /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
+  /* ======================================================================== */
+
+  /**
+    * Summon an instance of [[QueryKeyValue]] for `A`.
+    */
+  @inline def apply[A](implicit instance: QueryKeyValue[A]): QueryKeyValue[A] = instance
+
+  object ops {
+    implicit def toAllQueryKeyValueOps[A](target: A)(implicit tc: QueryKeyValue[A]): AllOps[A] {
+      type TypeClassType = QueryKeyValue[A]
+    } =
+      new AllOps[A] {
+        type TypeClassType = QueryKeyValue[A]
+        val self: A = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
+  trait Ops[A] extends Serializable {
+    type TypeClassType <: QueryKeyValue[A]
+    def self: A
+    val typeClassInstance: TypeClassType
+    def queryKey: String = typeClassInstance.queryKey(self)
+    def queryValue: Option[String] = typeClassInstance.queryValue(self)
+    def queryKeyValue: (String, Option[String]) = typeClassInstance.queryKeyValue(self)
+  }
+  trait AllOps[A] extends Ops[A]
+  trait ToQueryKeyValueOps extends Serializable {
+    implicit def toQueryKeyValueOps[A](target: A)(implicit tc: QueryKeyValue[A]): Ops[A] {
+      type TypeClassType = QueryKeyValue[A]
+    } =
+      new Ops[A] {
+        type TypeClassType = QueryKeyValue[A]
+        val self: A = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
+  object nonInheritedOps extends ToQueryKeyValueOps
+
+  /* ======================================================================== */
+  /* END OF SIMULACRUM-MANAGED CODE                                           */
+  /* ======================================================================== */
+
 }
 
 sealed trait QueryKeyValueInstances {
@@ -92,7 +227,8 @@ sealed trait QueryKeyValueInstances {
     QueryKeyValue(_._1, _._2)
 }
 
-@typeclass trait TraversableParams[A] {
+@implicitNotFound("Could not find an instance of TraversableParams for ${A}")
+@typeclass trait TraversableParams[A] extends Serializable {
   def toSeq(a: A): Seq[(String, Option[String])]
   def toVector(a: A): Vector[(String, Option[String])] =
     toSeq(a).toVector
@@ -119,6 +255,50 @@ object TraversableParams extends TraversableParamsInstances {
 
   def product[A, R <: HList](implicit gen: LabelledGeneric.Aux[A, R], R: TraversableParams[R]): TraversableParams[A] =
     (a: A) => R.toSeq(gen.to(a))
+
+  /* ======================================================================== */
+  /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
+  /* ======================================================================== */
+
+  /**
+    * Summon an instance of [[TraversableParams]] for `A`.
+    */
+  @inline def apply[A](implicit instance: TraversableParams[A]): TraversableParams[A] = instance
+
+  object ops {
+    implicit def toAllTraversableParamsOps[A](target: A)(implicit tc: TraversableParams[A]): AllOps[A] {
+      type TypeClassType = TraversableParams[A]
+    } =
+      new AllOps[A] {
+        type TypeClassType = TraversableParams[A]
+        val self: A = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
+  trait Ops[A] extends Serializable {
+    type TypeClassType <: TraversableParams[A]
+    def self: A
+    val typeClassInstance: TypeClassType
+    def toSeq: Seq[(String, Option[String])] = typeClassInstance.toSeq(self)
+    def toVector: Vector[(String, Option[String])] = typeClassInstance.toVector(self)
+  }
+  trait AllOps[A] extends Ops[A]
+  trait ToTraversableParamsOps extends Serializable {
+    implicit def toTraversableParamsOps[A](target: A)(implicit tc: TraversableParams[A]): Ops[A] {
+      type TypeClassType = TraversableParams[A]
+    } =
+      new Ops[A] {
+        type TypeClassType = TraversableParams[A]
+        val self: A = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
+  object nonInheritedOps extends ToTraversableParamsOps
+
+  /* ======================================================================== */
+  /* END OF SIMULACRUM-MANAGED CODE                                           */
+  /* ======================================================================== */
+
 }
 
 sealed trait TraversableParamsInstances1 {


### PR DESCRIPTION
Use scalafix-simulacrum to generate typeclass boilerplate instead of macros. 

Fixes #152, #160. Relates to #154.
