### PR TITLE
Do not allow forward slashes in user info unless percent encoded as per RFC-3986

### DIFF
--- a/shared/src/main/scala/io/lemonlabs/uri/parsing/UrlParser.scala
+++ b/shared/src/main/scala/io/lemonlabs/uri/parsing/UrlParser.scala
@@ -89,7 +89,7 @@ class UrlParser(val input: ParserInput)(implicit conf: UriConfig = UriConfig.def
   def _user_info: Rule1[UserInfo] =
     rule {
       capture(zeroOrMore(noneOf(":/?[]@ \t\r\n"))) ~ optional(
-        ":" ~ capture(zeroOrMore(noneOf("@")))
+        ":" ~ capture(zeroOrMore(noneOf("/@")))
       ) ~ "@" ~> extractUserInfo
     }
 

--- a/shared/src/test/scala/io/lemonlabs/uri/GithubIssuesTests.scala
+++ b/shared/src/test/scala/io/lemonlabs/uri/GithubIssuesTests.scala
@@ -59,4 +59,11 @@ class GithubIssuesTests extends AnyFlatSpec with Matchers with OptionValues {
         e.getMessage should startWith(s"Invalid Url could not be parsed. Invalid input '$chToString'")
     }
   }
+
+  "Github Issue #192" should "not allow forward slashes in passwords unless percent encoded" in {
+    val url = Url.parse("http://example.com:123/@path:")
+    url.hostOption should equal(Some(DomainName("example.com")))
+    url.port should equal(Some(123))
+    url.path.toString() should equal("/@path:")
+  }
 }


### PR DESCRIPTION
This fixes #192 where the parser was being to eager to find userinfo where there wasn't any