### PR TITLE
Parse IP prefix hosts

### DIFF
--- a/shared/src/main/scala/io/lemonlabs/uri/parsing/UrlParser.scala
+++ b/shared/src/main/scala/io/lemonlabs/uri/parsing/UrlParser.scala
@@ -77,9 +77,7 @@ class UrlParser(val input: ParserInput)(implicit conf: UriConfig = UriConfig.def
     }
 
   def _host: Rule1[Host] =
-    rule {
-      _ip_v4 | _ip_v6 | _domain_name
-    }
+    _host_in_authority("")
 
   /**
     * To ensure that hosts that begin with an IP but have further leading characters are not matched as IPs,

--- a/shared/src/test/scala/io/lemonlabs/uri/GithubIssuesTests.scala
+++ b/shared/src/test/scala/io/lemonlabs/uri/GithubIssuesTests.scala
@@ -76,4 +76,8 @@ class GithubIssuesTests extends AnyFlatSpec with Matchers with OptionValues {
     val url = Url.parse("https://[E873:4eC5:eBc9:9e97:6BcE:998C:95AD::]/")
     url.hostOption should equal(Some(IpV6("e873", "4ec5", "ebc9", "9e97", "6bce", "998c", "95ad", "0")))
   }
+
+  "Github Issue #204" should "parse a domain name host with IPv4 prefix" in {
+    Host.parse("1.2.3.4.blah")
+  }
 }

--- a/shared/src/test/scala/io/lemonlabs/uri/GithubIssuesTests.scala
+++ b/shared/src/test/scala/io/lemonlabs/uri/GithubIssuesTests.scala
@@ -78,6 +78,6 @@ class GithubIssuesTests extends AnyFlatSpec with Matchers with OptionValues {
   }
 
   "Github Issue #204" should "parse a domain name host with IPv4 prefix" in {
-    Host.parse("1.2.3.4.blah")
+    Host.parse("1.2.3.4.blah") should equal(DomainName("1.2.3.4.blah"))
   }
 }


### PR DESCRIPTION
Fix for #120 

This was already fixed for hosts when using `Url.parse` at https://github.com/lemonlabsuk/scala-uri/commit/793e09b86ec733f9fe8db6af8094cd5e3aee78d8#diff-dd4de85bc27c275c5fc355a5661fb6f2R56, but was not reflected in the standalone `Host.parse`