### PR TITLE
Encode spaces as pluses in query parameters by default. Decode pluses to spaces in query parameters by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,17 +336,35 @@ implicit val config = UriConfig(encoder = percentEncode ++ ('a', 'b'))
 
 ### Encoding spaces as pluses
 
-The default behaviour with scala uri, is to encode spaces as `%20`, however if you instead wish them to be encoded as the `+` symbol, then simply add the following `implicit val` to your code:
+The default behaviour with scala-uri, is to encode spaces as `+` in the querystring and as `%20` elsewhere in the URL.
+
+If you instead wish spaces to be encoded as `%20` in the query, then simply add the following `implicit val` to your code:
 
 ```scala mdoc:reset
 import io.lemonlabs.uri.Url
 import io.lemonlabs.uri.config.UriConfig
 import io.lemonlabs.uri.encoding._
+import io.lemonlabs.uri.encoding.PercentEncoder._
 
-implicit val config = UriConfig(encoder = percentEncode + spaceAsPlus)
+implicit val config = UriConfig.default.copy(queryEncoder = PercentEncoder())
 
-val uri = Url.parse("http://theon.github.com/uri with space")
-uri.toString // This is http://theon.github.com/uri+with+space
+val uri = Url.parse("http://theon.github.com?test=uri with space")
+uri.toString // This is http://theon.github.com?test=uri%20with%20space
+```
+
+The default behaviour with scala-uri, is to decode `+` in query string parameters to spaces and to leave it as a literal `+` elsewhere in the URL.
+
+If you instead wish `+` to be left as `+` in the query, then simply add the following `implicit val` to your code:
+
+```scala mdoc:reset
+import io.lemonlabs.uri.Url
+import io.lemonlabs.uri.config.UriConfig
+import io.lemonlabs.uri.decoding._
+
+implicit val config = UriConfig.default.copy(queryDecoder = PercentDecoder)
+
+val uri = Url.parse("http://theon.github.com?test=uri+with+plus")
+uri.query.param("test") // This is Some("uri+with+plus")
 ```
 
 ### Custom encoding
@@ -854,6 +872,13 @@ For maven users you should use (for 2.13.x):
 Contributions to `scala-uri` are always welcome. Check out the [Contributing Guidelines](https://github.com/lemonlabsuk/scala-uri/blob/master/README.md)
 
 # Migration guides
+
+## 2.x.x to 3.x.x
+
+ * *Backwards Incompatible*: The space character is now encoded to `+` instead of `%20` in query string parameters by default.   
+ * *Backwards Incompatible*: The `+` method in `io.lemonlabs.uri.encoding.UriEncoder`, now chains encoders in the opposite order to be more intuitive.
+   E.g. `a + b` will encode with encoder `a` first, followed by encoder `b`
+ 
 
 ## 1.x.x to 2.x.x
 

--- a/build.sbt
+++ b/build.sbt
@@ -163,10 +163,11 @@ lazy val scalaUri =
     .settings(scalaUriSettings)
     .settings(publishingSettings)
     .settings(mimaSettings)
-    .jsSettings(
-      libraryDependencies += "org.scala-js" %%% "scalajs-dom" % "1.1.0"
+    .jvmSettings(
+      fork in Test := true
     )
     .jsSettings(
+      libraryDependencies += "org.scala-js" %%% "scalajs-dom" % "1.1.0",
       //scalac-scoverage-plugin Scala.js 1.0 is not yet released.
       coverageEnabled := false
     )

--- a/jvm/src/test/scala/io/lemonlabs/uri/SerializableTests.scala
+++ b/jvm/src/test/scala/io/lemonlabs/uri/SerializableTests.scala
@@ -21,13 +21,13 @@ class SerializableTests extends AnyFlatSpec with Matchers {
   }
 
   it should "uri can serializable" in {
-    val uri = Uri.parse("http://example.com/path/?key=value#flagment")
+    val uri = Uri.parse("http://example.com/path/?key=value#fragment")
 
     serializeAndDeserialize(uri) should equal(uri)
   }
 
   it should "uri can serializable, decoder = NoopDecoder" in {
-    val uri = Uri.parse("http://example.com/path/?key=value#flagment")(UriConfig(decoder = NoopDecoder))
+    val uri = Uri.parse("http://example.com/path/?key=value#fragment")(UriConfig(decoder = NoopDecoder))
 
     serializeAndDeserialize(uri) should equal(uri)
   }

--- a/shared/src/main/scala/io/lemonlabs/uri/config/UriConfig.scala
+++ b/shared/src/main/scala/io/lemonlabs/uri/config/UriConfig.scala
@@ -1,8 +1,8 @@
 package io.lemonlabs.uri.config
 
-import io.lemonlabs.uri.decoding.{PercentDecoder, UriDecoder}
+import io.lemonlabs.uri.decoding.{plusAsSpace, PercentDecoder, UriDecoder}
 import io.lemonlabs.uri.encoding.PercentEncoder._
-import io.lemonlabs.uri.encoding.{NoopEncoder, PercentEncoder, UriEncoder}
+import io.lemonlabs.uri.encoding.{spaceAsPlus, NoopEncoder, PercentEncoder, UriEncoder}
 
 case class UriConfig(userInfoEncoder: UriEncoder,
                      pathEncoder: UriEncoder,
@@ -22,11 +22,11 @@ object UriConfig {
   val default = UriConfig(
     userInfoEncoder = PercentEncoder(USER_INFO_CHARS_TO_ENCODE),
     pathEncoder = PercentEncoder(PATH_CHARS_TO_ENCODE),
-    queryEncoder = PercentEncoder(QUERY_CHARS_TO_ENCODE),
+    queryEncoder = PercentEncoder(QUERY_CHARS_TO_ENCODE) + spaceAsPlus,
     fragmentEncoder = PercentEncoder(FRAGMENT_CHARS_TO_ENCODE),
     userInfoDecoder = PercentDecoder,
     pathDecoder = PercentDecoder,
-    queryDecoder = PercentDecoder,
+    queryDecoder = plusAsSpace + PercentDecoder,
     fragmentDecoder = PercentDecoder,
     charset = "UTF-8",
     renderQuery = RenderQuery.default
@@ -35,7 +35,12 @@ object UriConfig {
   /** Probably more than you need to percent encode. Wherever possible try to use a tighter Set of characters
     * to encode depending on your use case
     */
-  val conservative = UriConfig(PercentEncoder(), PercentDecoder)
+  val conservative = default.copy(
+    userInfoEncoder = PercentEncoder(),
+    pathEncoder = PercentEncoder(),
+    queryEncoder = PercentEncoder() + spaceAsPlus,
+    fragmentEncoder = PercentEncoder()
+  )
 
   def apply(encoder: UriEncoder = PercentEncoder(),
             decoder: UriDecoder = PercentDecoder,

--- a/shared/src/main/scala/io/lemonlabs/uri/decoding/ChainedUriDecoder.scala
+++ b/shared/src/main/scala/io/lemonlabs/uri/decoding/ChainedUriDecoder.scala
@@ -1,0 +1,18 @@
+package io.lemonlabs.uri.decoding
+
+case class ChainedUriDecoder(decoders: Seq[UriDecoder]) extends UriDecoder {
+
+  override def decodeBytes(data: String, charset: String): Array[Byte] = {
+    val asStr = decoders.foldLeft(data) { (str, decoder) =>
+      new String(decoder.decodeBytes(str, charset), charset)
+    }
+    asStr.getBytes(charset)
+  }
+
+  override def decode(data: String): String =
+    decoders.foldLeft(data) { (str, decoder) =>
+      decoder.decode(str)
+    }
+
+  override def +(encoder: UriDecoder): ChainedUriDecoder = copy(decoders = decoders :+ encoder)
+}

--- a/shared/src/main/scala/io/lemonlabs/uri/decoding/DecodeCharAs.scala
+++ b/shared/src/main/scala/io/lemonlabs/uri/decoding/DecodeCharAs.scala
@@ -1,0 +1,9 @@
+package io.lemonlabs.uri.decoding
+
+case class DecodeCharAs(ch: Char, as: String) extends UriDecoder {
+  override def decodeBytes(data: String, charset: String): Array[Byte] =
+    decode(data).getBytes(charset)
+
+  override def decode(data: String): String =
+    data.replace(ch.toString, as)
+}

--- a/shared/src/main/scala/io/lemonlabs/uri/decoding/UriDecoder.scala
+++ b/shared/src/main/scala/io/lemonlabs/uri/decoding/UriDecoder.scala
@@ -7,4 +7,6 @@ trait UriDecoder extends Product with Serializable {
 
   def decodeTuple(kv: (String, Option[String])) =
     decode(kv._1) -> kv._2.map(decode)
+
+  def +(other: UriDecoder) = ChainedUriDecoder(this :: other :: Nil)
 }

--- a/shared/src/main/scala/io/lemonlabs/uri/decoding/package.scala
+++ b/shared/src/main/scala/io/lemonlabs/uri/decoding/package.scala
@@ -1,0 +1,8 @@
+package io.lemonlabs.uri
+
+package object decoding {
+  val percentDecode: PercentDecoder = PercentDecoder
+
+  def decodeCharAs(c: Char, as: String) = DecodeCharAs(c, as)
+  val plusAsSpace = DecodeCharAs('+', " ")
+}

--- a/shared/src/main/scala/io/lemonlabs/uri/encoding/ChainedUriEncoder.scala
+++ b/shared/src/main/scala/io/lemonlabs/uri/encoding/ChainedUriEncoder.scala
@@ -11,5 +11,5 @@ case class ChainedUriEncoder(encoders: Seq[UriEncoder]) extends UriEncoder {
     encoders.find(_.shouldEncode(ch))
   }
 
-  override def +(encoder: UriEncoder) = copy(encoders = encoder +: encoders)
+  override def +(encoder: UriEncoder) = copy(encoders = encoders :+ encoder)
 }

--- a/shared/src/main/scala/io/lemonlabs/uri/encoding/PercentEncoder.scala
+++ b/shared/src/main/scala/io/lemonlabs/uri/encoding/PercentEncoder.scala
@@ -28,7 +28,7 @@ object PercentEncoder {
   )
 
   val QUERY_CHARS_TO_ENCODE = Set(
-    ' ', '%', '<', '>', '[', ']', '#', '{', '}', '^', '`', '|', '&', '\\', '+', '='
+    '%', '<', '>', '[', ']', '#', '{', '}', '^', '`', '|', '&', '\\', '+', '='
   )
 
   val FRAGMENT_CHARS_TO_ENCODE = Set(

--- a/shared/src/main/scala/io/lemonlabs/uri/encoding/UriEncoder.scala
+++ b/shared/src/main/scala/io/lemonlabs/uri/encoding/UriEncoder.scala
@@ -22,5 +22,5 @@ trait UriEncoder extends Product with Serializable {
     new String(encChars, charset)
   }
 
-  def +(other: UriEncoder) = ChainedUriEncoder(other :: this :: Nil)
+  def +(other: UriEncoder) = ChainedUriEncoder(this :: other :: Nil)
 }

--- a/shared/src/test/scala/io/lemonlabs/uri/DataUrlTests.scala
+++ b/shared/src/test/scala/io/lemonlabs/uri/DataUrlTests.scala
@@ -1,6 +1,7 @@
 package io.lemonlabs.uri
 
 import io.lemonlabs.uri.config.UriConfig
+import io.lemonlabs.uri.decoding.{decodeCharAs, PercentDecoder}
 import io.lemonlabs.uri.encoding.PercentEncoder
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -142,5 +143,13 @@ class DataUrlTests extends AnyFlatSpec with Matchers {
     val absoluteUrl = dataUrl.withAuthority(Authority("example.com", 8080))
     absoluteUrl shouldBe an[AbsoluteUrl]
     absoluteUrl.toString() should equal("data://example.com:8080/,A%20brief%20note")
+  }
+
+  "Path decoder" should "be used to decode data" in {
+    implicit val config: UriConfig = UriConfig.default.copy(
+      pathDecoder = decodeCharAs('A', "One") + decodeCharAs('0', "6") + PercentDecoder
+    )
+    val dataUrl = DataUrl.parse("data:,A%20brief%20note")
+    dataUrl.dataAsString should equal("One&brief&note")
   }
 }

--- a/shared/src/test/scala/io/lemonlabs/uri/DecodingTests.scala
+++ b/shared/src/test/scala/io/lemonlabs/uri/DecodingTests.scala
@@ -1,6 +1,6 @@
 package io.lemonlabs.uri
 
-import io.lemonlabs.uri.decoding.{NoopDecoder, UriDecodeException}
+import io.lemonlabs.uri.decoding.{NoopDecoder, PercentDecoder, UriDecodeException}
 import io.lemonlabs.uri.config.UriConfig
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -55,5 +55,26 @@ class DecodingTests extends AnyFlatSpec with Matchers {
     intercept[UriDecodeException] {
       Uri.parse("%")
     }
+  }
+
+  "Pluses decoded to space" should "be enabled in the query by default" in {
+    val uri = Url.parse("https://github.com/scala-uri?a+test=with+plus")
+    uri.query.param("a test") should equal(Some("with plus"))
+  }
+
+  it should "be disabled in the path by default" in {
+    val uri = Url.parse("https://github.com/scala+uri")
+    uri.path.toString() should equal("/scala+uri")
+  }
+
+  it should "allow %2B to be decoded to +" in {
+    val uri = Url.parse("https://github.com/scala-uri?a%2Btest=with%2Bplus")
+    uri.query.param("a+test") should equal(Some("with+plus"))
+  }
+
+  it should "be possible to disable in the query" in {
+    implicit val conf: UriConfig = UriConfig(decoder = PercentDecoder)
+    val uri = Url.parse("https://github.com/scala-uri?a+test=with+plus")
+    uri.query.param("a+test") should equal(Some("with+plus"))
   }
 }

--- a/shared/src/test/scala/io/lemonlabs/uri/EncodingTests.scala
+++ b/shared/src/test/scala/io/lemonlabs/uri/EncodingTests.scala
@@ -40,9 +40,10 @@ class EncodingTests extends AnyFlatSpec with Matchers {
   }
 
   "Path chars" should "be encoded as custom strings if configured" in {
-    implicit val config: UriConfig = UriConfig(encoder = encodeCharAs(' ', "_") + percentEncode)
+    implicit val config: UriConfig =
+      UriConfig(encoder = encodeCharAs(' ', "_") + encodeCharAs('e', "es") + percentEncode)
     val url = Url.parse("http://theon.github.com/uri with space")
-    url.toString should equal("http://theon.github.com/uri_with_space")
+    url.toString should equal("http://theon.github.com/uri_with_spaces")
   }
 
   "Querystring parameters" should "be percent encoded" in {

--- a/shared/src/test/scala/io/lemonlabs/uri/EncodingTests.scala
+++ b/shared/src/test/scala/io/lemonlabs/uri/EncodingTests.scala
@@ -1,6 +1,7 @@
 package io.lemonlabs.uri
 
 import io.lemonlabs.uri.config.UriConfig
+import io.lemonlabs.uri.decoding.PercentDecoder
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -33,20 +34,20 @@ class EncodingTests extends AnyFlatSpec with Matchers {
   }
 
   "URI path spaces" should "be plus encoded if configured" in {
-    implicit val config: UriConfig = UriConfig(encoder = percentEncode + spaceAsPlus)
+    implicit val config: UriConfig = UriConfig(encoder = spaceAsPlus + percentEncode)
     val url = Url.parse("http://theon.github.com/uri with space")
     url.toString should equal("http://theon.github.com/uri+with+space")
   }
 
   "Path chars" should "be encoded as custom strings if configured" in {
-    implicit val config: UriConfig = UriConfig(encoder = percentEncode + encodeCharAs(' ', "_"))
+    implicit val config: UriConfig = UriConfig(encoder = encodeCharAs(' ', "_") + percentEncode)
     val url = Url.parse("http://theon.github.com/uri with space")
     url.toString should equal("http://theon.github.com/uri_with_space")
   }
 
   "Querystring parameters" should "be percent encoded" in {
-    val url = Url.parse("http://theon.github.com/uris-in-scala.html?càsh=+£50&©opyright=false")
-    url.toString should equal("http://theon.github.com/uris-in-scala.html?c%C3%A0sh=%2B%C2%A350&%C2%A9opyright=false")
+    val url = Url.parse("http://theon.github.com/uris-in-scala.html?càsh=£50&©opyright=false")
+    url.toString should equal("http://theon.github.com/uris-in-scala.html?c%C3%A0sh=%C2%A350&%C2%A9opyright=false")
   }
 
   "Querystring double quotes" should "be percent encoded when using conservative encoder" in {
@@ -117,5 +118,26 @@ class EncodingTests extends AnyFlatSpec with Matchers {
     Url.parse("/%2F/").toString() should equal("/%2F/")
     val builtUrl = Url.parse("http://example.com").addPathPart("1/2")
     builtUrl.toString() should equal("http://example.com/1%2F2")
+  }
+
+  "Spaces encoded to plus" should "be enabled in the query by default" in {
+    val uri = Url.parse("https://github.com/scala-uri").addParam("a test", "with plus")
+    uri.toString() should equal("https://github.com/scala-uri?a+test=with+plus")
+  }
+
+  it should "be disabled in the path by default" in {
+    val uri = Url.parse("https://github.com/scala-uri").addPathPart("a test")
+    uri.path.toString() should equal("/scala-uri/a%20test")
+  }
+
+  it should "encode + as %2B" in {
+    val uri = Url.parse("https://github.com/scala-uri").addParam("a+test", "with+plus")
+    uri.toString() should equal("https://github.com/scala-uri?a%2Btest=with%2Bplus")
+  }
+
+  it should "be possible to disable in the query" in {
+    implicit val conf: UriConfig = UriConfig(encoder = PercentEncoder())
+    val uri = Url.parse("https://github.com/scala-uri").addParam("a test", "with plus")
+    uri.toString() should equal("https://github.com/scala-uri?a%20test=with%20plus")
   }
 }

--- a/shared/src/test/scala/io/lemonlabs/uri/NapGithubIssueTests.scala
+++ b/shared/src/test/scala/io/lemonlabs/uri/NapGithubIssueTests.scala
@@ -2,6 +2,7 @@ package io.lemonlabs.uri
 
 import io.lemonlabs.uri.config.UriConfig
 import io.lemonlabs.uri.decoding.PermissivePercentDecoder
+import io.lemonlabs.uri.encoding.PercentEncoder
 import io.lemonlabs.uri.parsing.UriParsingException
 import org.scalatest.OptionValues
 import org.scalatest.flatspec.AnyFlatSpec
@@ -13,7 +14,7 @@ import org.scalatest.matchers.should.Matchers
   */
 class NapGithubIssueTests extends AnyFlatSpec with Matchers with OptionValues {
   "Github Issue #2" should "now be fixed. Pluses in querystrings should be encoded when using the conservative encoder" in {
-    val uri = Url.parse("http://theon.github.com/?+=+")
+    val uri = Url.parse("http://theon.github.com/").addParam("+", "+")
     uri.toString(UriConfig.conservative) should equal("http://theon.github.com/?%2B=%2B")
   }
 
@@ -113,6 +114,7 @@ class NapGithubIssueTests extends AnyFlatSpec with Matchers with OptionValues {
   }
 
   "Github Issue #65 example 2" should "now be fixed" in {
+    implicit val conf: UriConfig = UriConfig(encoder = PercentEncoder())
     val uri = Url.parse(
       "http://localhost:9000/mlb/2014/06/15/david-wrights-slump-continues-why-new-york-mets-franchise-third-baseman-must-be-gone-before-seasons-end/?utm_source=RantSports&utm_medium=HUBRecirculation&utm_term=MLBNew York MetsGrid"
     )


### PR DESCRIPTION
Fixes #219 


