### PR TITLE
Add equalsUnordered method for comparing Urls without considering query parameter order

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,62 @@ val url = Url.parse("http://user:password@example.com?secret=123&other=true")
 url.toRedactedString(Redact.byRemoving.allParams().userInfo())
 ```
 
+## Url Equality
+
+By default scala-uri only considers `Url`s equal if query parameters are in the same order:
+
+```scala mdoc:reset
+import io.lemonlabs.uri._
+
+val urlOne = Url.parse("https://example.com?a=1&b=2")
+val urlTwo = Url.parse("https://example.com?b=2&a=1")
+
+urlOne == urlTwo // this is false
+
+val urlThree = Url.parse("https://example.com?a=1&b=2")
+
+urlOne == urlThree // this is true
+```
+
+For use-cases where query parameter order is not important, the `equalsUnordered` can be used
+
+```scala mdoc
+urlOne.equalsUnordered(urlTwo) // this is true
+```
+
+When using cats for equality testing, parameter order will also be considered by default
+
+```scala mdoc
+import cats.implicits._
+
+urlOne === urlTwo   // this is false
+urlOne === urlThree // this is true
+```
+
+With cats, query parameter order can be ignored for equality checks with the following import:
+
+```scala mdoc
+import io.lemonlabs.uri.Url.unordered._
+
+urlOne === urlTwo   // this is true
+urlOne === urlThree // this is true
+```
+
+Note: depending on the type you are comparing, you will need to import a different cats `Eq` instance. 
+The following are available:
+
+```scala mdoc:reset
+import io.lemonlabs.uri.Uri.unordered._
+import io.lemonlabs.uri.Url.unordered._
+import io.lemonlabs.uri.RelativeUrl.unordered._
+import io.lemonlabs.uri.UrlWithAuthority.unordered._
+import io.lemonlabs.uri.ProtocolRelativeUrl.unordered._
+import io.lemonlabs.uri.AbsoluteUrl.unordered._
+import io.lemonlabs.uri.UrlWithoutAuthority.unordered._
+import io.lemonlabs.uri.SimpleUrlWithoutAuthority.unordered._
+import io.lemonlabs.uri.QueryString.unordered._
+```
+
 ## Pattern Matching URIs
 
 ```scala mdoc:reset

--- a/build.sbt
+++ b/build.sbt
@@ -117,7 +117,8 @@ val previousVersions = (0 to 0).map(v => s"3.$v.0").toSet
 
 val mimaExcludes = Seq(
   ProblemFilters.exclude[ReversedMissingMethodProblem]("io.lemonlabs.uri.typesafe.QueryValueInstances1.*"),
-  ProblemFilters.exclude[ReversedMissingMethodProblem]("io.lemonlabs.uri.Url.*")
+  ProblemFilters.exclude[ReversedMissingMethodProblem]("io.lemonlabs.uri.Url.*"),
+  ProblemFilters.exclude[ReversedMissingMethodProblem]("io.lemonlabs.uri.Uri.*")
 )
 
 val mimaSettings = Seq(

--- a/shared/src/main/scala/io/lemonlabs/uri/QueryString.scala
+++ b/shared/src/main/scala/io/lemonlabs/uri/QueryString.scala
@@ -229,6 +229,11 @@ case class QueryString(params: Vector[(String, Option[String])])(implicit config
     else paramsAsString.mkString("&")
   }
 
+  private def paramsCardinality = params.groupBy(identity)
+
+  def equalsUnordered(other: QueryString): Boolean =
+    this.paramsCardinality == other.paramsCardinality
+
   /** Returns the query string with no encoding taking place (e.g. non ASCII characters will not be percent encoded)
     * @return String containing the raw query string for this Uri
     */
@@ -263,4 +268,9 @@ object QueryString {
   implicit val eqQueryString: Eq[QueryString] = Eq.fromUniversalEquals
   implicit val showQueryString: Show[QueryString] = Show.fromToString
   implicit val orderQueryString: Order[QueryString] = Order.by(_.params)
+
+  object unordered {
+    implicit val eqQueryString: Eq[QueryString] =
+      (x: QueryString, y: QueryString) => x.equalsUnordered(y)
+  }
 }

--- a/shared/src/test/scala/io/lemonlabs/uri/CatsTests.scala
+++ b/shared/src/test/scala/io/lemonlabs/uri/CatsTests.scala
@@ -17,9 +17,27 @@ class CatsTests extends AnyFlatSpec with Matchers {
     (uri === uri2) should equal(true)
   }
 
+  it should "be supported for unordered query params Uri" in new CatsTestCase {
+    import Uri.unordered._
+
+    val uri = Uri.parse("https://typelevel.org/cats/?a=1&b=two")
+    val uri2: Uri = AbsoluteUrl.parse("https://typelevel.org/cats/?b=two&a=1")
+
+    (uri === uri2) should equal(true)
+  }
+
   it should "be supported for Url" in new CatsTestCase {
     val uri = Url.parse("https://typelevel.org/cats/")
     val uri2: Url = AbsoluteUrl.parse("https://typelevel.org/cats/")
+
+    (uri === uri2) should equal(true)
+  }
+
+  it should "be supported unordered query params Url" in new CatsTestCase {
+    import Url.unordered._
+
+    val uri = Url.parse("https://typelevel.org/cats/?a=1&b=two")
+    val uri2: Url = AbsoluteUrl.parse("https://typelevel.org/cats/?b=two&a=1")
 
     (uri === uri2) should equal(true)
   }
@@ -31,9 +49,27 @@ class CatsTests extends AnyFlatSpec with Matchers {
     (uri === uri2) should equal(false)
   }
 
+  it should "be supported for unordered query params RelativeUrl" in new CatsTestCase {
+    import RelativeUrl.unordered._
+
+    val uri = RelativeUrl.parse("/cats2/?b=two&a=1")
+    val uri2 = RelativeUrl.parse("/cats/?a=1&b=two")
+
+    (uri === uri2) should equal(false)
+  }
+
   it should "be supported for UrlWithAuthority" in new CatsTestCase {
     val uri = UrlWithAuthority.parse("https://typelevel.org/cats/")
     val uri2: UrlWithAuthority = AbsoluteUrl.parse("https://typelevel.org/cats/")
+
+    (uri === uri2) should equal(true)
+  }
+
+  it should "be supported for unordered query params UrlWithAuthority" in new CatsTestCase {
+    import UrlWithAuthority.unordered._
+
+    val uri = UrlWithAuthority.parse("https://typelevel.org/cats/?a=1&b=two")
+    val uri2: UrlWithAuthority = AbsoluteUrl.parse("https://typelevel.org/cats/?b=two&a=1")
 
     (uri === uri2) should equal(true)
   }
@@ -45,9 +81,27 @@ class CatsTests extends AnyFlatSpec with Matchers {
     (uri =!= uri2) should equal(true)
   }
 
+  it should "be supported for unordered query params ProtocolRelativeUrl" in new CatsTestCase {
+    import ProtocolRelativeUrl.unordered._
+
+    val uri = ProtocolRelativeUrl.parse("//typelevel.org/cats/?b=two&a=1")
+    val uri2 = ProtocolRelativeUrl.parse("//typelevel.org/cats/?a=1&b=two")
+
+    (uri =!= uri2) should equal(false)
+  }
+
   it should "be supported for AbsoluteUrl" in new CatsTestCase {
     val uri = AbsoluteUrl.parse("https://typelevel.org/cats/")
     val uri2 = AbsoluteUrl.parse("https://typelevel.org/cats/")
+
+    (uri === uri2) should equal(true)
+  }
+
+  it should "be supported for unordered query params AbsoluteUrl" in new CatsTestCase {
+    import AbsoluteUrl.unordered._
+
+    val uri = AbsoluteUrl.parse("https://typelevel.org/cats/?a=1&b=two")
+    val uri2 = AbsoluteUrl.parse("https://typelevel.org/cats/?b=two&a=1")
 
     (uri === uri2) should equal(true)
   }
@@ -59,9 +113,27 @@ class CatsTests extends AnyFlatSpec with Matchers {
     (uri === uri2) should equal(false)
   }
 
+  it should "be supported for unordered query params UrlWithoutAuthority" in new CatsTestCase {
+    import UrlWithoutAuthority.unordered._
+
+    val uri = UrlWithoutAuthority.parse("mailto:someone@somewhere.com?b=two&a=1")
+    val uri2 = UrlWithoutAuthority.parse("mailto:someoneelse@somewhereelse.com?a=1&b=two")
+
+    (uri === uri2) should equal(false)
+  }
+
   it should "be supported for SimpleUrlWithoutAuthority" in new CatsTestCase {
     val uri = SimpleUrlWithoutAuthority.parse("mailto:someone@somewhere.com")
     val uri2 = SimpleUrlWithoutAuthority.parse("mailto:someone@somewhere.com")
+
+    (uri === uri2) should equal(true)
+  }
+
+  it should "be supported for unordered query params SimpleUrlWithoutAuthority" in new CatsTestCase {
+    import SimpleUrlWithoutAuthority.unordered._
+
+    val uri = SimpleUrlWithoutAuthority.parse("mailto:someone@somewhere.com?a=1&b=two")
+    val uri2 = SimpleUrlWithoutAuthority.parse("mailto:someone@somewhere.com?b=two&a=1")
 
     (uri === uri2) should equal(true)
   }
@@ -183,6 +255,21 @@ class CatsTests extends AnyFlatSpec with Matchers {
     val qs2 = QueryString.parse("a=1&b=2")
 
     (qs === qs2) should equal(true)
+  }
+
+  it should "be supported for unordered QueryString" in new CatsTestCase {
+    val qs = QueryString.parse("a=1&b=2")
+    val qs2 = QueryString.parse("b=2&a=1")
+
+    import QueryString.unordered._
+    (qs === qs2) should equal(true)
+  }
+
+  it should "be supported for ordered QueryString" in new CatsTestCase {
+    val qs = QueryString.parse("a=1&b=2")
+    val qs2 = QueryString.parse("b=2&a=1")
+
+    (qs === qs2) should equal(false)
   }
 
   "Show" should "be supported for Uri" in {

--- a/shared/src/test/scala/io/lemonlabs/uri/EqualityTests.scala
+++ b/shared/src/test/scala/io/lemonlabs/uri/EqualityTests.scala
@@ -1,0 +1,121 @@
+package io.lemonlabs.uri
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+
+class EqualityTests extends AnyFlatSpec with Matchers with ScalaCheckDrivenPropertyChecks {
+  "QueryString.equalsUnordered" should "require the same number of identical parameters" in {
+    val qsOne = QueryString.parse("a=1&a=1&a=1&a=1")
+    val qsTwo = QueryString.parse("a=1&a=1&a=1")
+    qsOne.equalsUnordered(qsTwo) should equal(false)
+  }
+
+  it should "require the same number of value-less parameters" in {
+    val qsOne = QueryString.parse("a=1&a")
+    val qsTwo = QueryString.parse("a=1")
+    qsOne.equalsUnordered(qsTwo) should equal(false)
+  }
+
+  it should "require the same number of empty parameters" in {
+    val qsOne = QueryString.parse("a=1&a=")
+    val qsTwo = QueryString.parse("a=1")
+    qsOne.equalsUnordered(qsTwo) should equal(false)
+  }
+
+  it should "match when in the same order" in {
+    val qsOne = QueryString.parse("a=1&b=2&b=2")
+    val qsTwo = QueryString.parse("a=1&b=2&b=2")
+    qsOne.equalsUnordered(qsTwo) should equal(true)
+  }
+
+  it should "match when in a different order" in {
+    val qsOne = QueryString.parse("a=1&b=2&b=2")
+    val qsTwo = QueryString.parse("b=2&a=1&b=2")
+    qsOne.equalsUnordered(qsTwo) should equal(true)
+  }
+
+  "Uri.equalsUnordered" should "require the same number of identical parameters" in {
+    val urlOne = Url.parse("http://example.com?a=1&a=1&a=1&a=1")
+    val urlTwo = Url.parse("http://example.com?a=1&a=1&a=1")
+    urlOne.equalsUnordered(urlTwo) should equal(false)
+  }
+
+  it should "require the same number of value-less parameters" in {
+    val urlOne = Url.parse("http://example.com?a=1&a")
+    val urlTwo = Url.parse("http://example.com?a=1")
+    urlOne.equalsUnordered(urlTwo) should equal(false)
+  }
+
+  it should "require the same number of empty parameters" in {
+    val urlOne = Url.parse("http://example.com?a=1&a=")
+    val urlTwo = Url.parse("http://example.com?a=1")
+    urlOne.equalsUnordered(urlTwo) should equal(false)
+  }
+
+  it should "match when in the same order" in {
+    val urlOne = Url.parse("http://example.com?a=1&b=2&b=2")
+    val urlTwo = Url.parse("http://example.com?a=1&b=2&b=2")
+    urlOne.equalsUnordered(urlTwo) should equal(true)
+  }
+
+  it should "match when in a different order" in {
+    val urlOne = Url.parse("http://example.com?a=1&b=2&b=2")
+    val urlTwo = Url.parse("http://example.com?b=2&a=1&b=2")
+    urlOne.equalsUnordered(urlTwo) should equal(true)
+  }
+
+  it should "not match URLs with URNs" in {
+    val urlOne = Url.parse("http://example.com")
+    val urnTwo = Urn.parse("urn:example:com")
+    urlOne.equalsUnordered(urnTwo) should equal(false)
+  }
+
+  it should "not match different types of URL" in {
+    val urlOne = Url.parse("http://example.com?a=1&b=2")
+    val urlTwo = Url.parse("//example.com?a=1&b=2")
+    urlOne.equalsUnordered(urlTwo) should equal(false)
+  }
+
+  it should "be the same as == for DataUrls" in {
+    val urlOne = DataUrl.parse("data:,A%20brief%20note")
+    val urlTwo = Url.parse("data:,A%20brief%20note")
+    urlOne.equalsUnordered(urlTwo) should equal(true)
+  }
+
+  it should "be the same as == for ScpUrls" in {
+    val urlOne = ScpLikeUrl.parse("root@host:/root/file.tar.gz")
+    val urlTwo = ScpLikeUrl.parse("root@host:/root/file.tar.gz")
+    urlOne.equalsUnordered(urlTwo) should equal(true)
+  }
+
+  it should "be the same as == for Urns" in {
+    val urnOne = Urn.parse("urn:example:com")
+    val urnTwo = Urn.parse("urn:example:com")
+    urnOne.equalsUnordered(urnTwo) should equal(true)
+  }
+
+  "DataUrl.equals" should "equal itself" in new UriScalaCheckGenerators {
+    forAll { dataUrl: DataUrl =>
+      (dataUrl == dataUrl) should equal(true)
+    }
+  }
+
+  it should "not equal another DataUrl" in new UriScalaCheckGenerators {
+    forAll { (dataUrl: DataUrl, dataUrl2: DataUrl) =>
+      (dataUrl == dataUrl2) should equal(false)
+    }
+  }
+
+  "DataUrl.hashCode" should "equal itself" in new UriScalaCheckGenerators {
+    forAll { dataUrl: DataUrl =>
+      dataUrl.hashCode() should equal(dataUrl.hashCode())
+    }
+  }
+
+  it should "not equal another DataUrl" in new UriScalaCheckGenerators {
+    forAll { (dataUrl: DataUrl, dataUrl2: DataUrl) =>
+      dataUrl.hashCode() should not equal dataUrl2.hashCode()
+    }
+  }
+}


### PR DESCRIPTION
As discussed in #282 
