### PR TITLE
type class derivation with scala 3 instead of shapeless

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -48,7 +48,7 @@ val sharedSettings = Seq(
 //  addCompilerPlugin(scalafixSemanticdb),
 //  scalacOptions ++= Seq(s"-P:semanticdb:targetroot:${baseDirectory.value}/target/.semanticdb", "-Yrangepos"),
   Test / parallelExecution := false,
-  scalafmtOnCompile        := true,
+//  scalafmtOnCompile        := true,
   coverageExcludedPackages := "(io.lemonlabs.uri.inet.Trie.*|io.lemonlabs.uri.inet.PublicSuffixes.*|io.lemonlabs.uri.inet.PublicSuffixTrie.*|io.lemonlabs.uri.inet.PunycodeSupport.*)"
 )
 
@@ -64,8 +64,6 @@ val scalaUriSettings = Seq(
   name        := "scala-uri",
   description := "Simple scala library for building and parsing URIs",
   libraryDependencies ++= Seq(
-    // TODO: Remove for3Use2_13 when scala3 version available https://github.com/milessabin/shapeless/issues/1043
-    ("com.chuusai"   %%% "shapeless"  % "2.3.7").cross(CrossVersion.for3Use2_13),
     "org.typelevel" %%% "cats-core"  % "2.6.1",
     "org.typelevel" %%% "cats-parse" % "0.3.4"
   ),

--- a/shared/src/main/scala/io/lemonlabs/uri/inet/PublicSuffixes.scala
+++ b/shared/src/main/scala/io/lemonlabs/uri/inet/PublicSuffixes.scala
@@ -34,7 +34,7 @@ object PublicSuffixes {
   )
 
   lazy val set: Set[String] = publicSuffixes0 ++ publicSuffixes1
-  private def publicSuffixes0 =
+  private def publicSuffixes0: Set[String] =
     Set(
       "ac",
       "com.ac",
@@ -5037,7 +5037,7 @@ object PublicSuffixes {
       "pf",
       "com.pf"
     )
-  private def publicSuffixes1 =
+  private def publicSuffixes1: Set[String] =
     Set(
       "org.pf",
       "edu.pf",

--- a/shared/src/main/scala/io/lemonlabs/uri/typesafe/QueryKeyValue.scala
+++ b/shared/src/main/scala/io/lemonlabs/uri/typesafe/QueryKeyValue.scala
@@ -1,15 +1,13 @@
 package io.lemonlabs.uri.typesafe
 
 import cats.Contravariant
-import cats.syntax.contravariant._
-import shapeless._
-import shapeless.labelled._
-import shapeless.ops.coproduct.Reify
-import shapeless.ops.hlist.ToList
+import cats.syntax.contravariant.*
 import simulacrum.typeclass
 
 import scala.language.implicitConversions
 import scala.annotation.implicitNotFound
+import scala.compiletime.package$package.{erasedValue, summonInline, summonFrom}
+import scala.deriving.Mirror
 
 @implicitNotFound("Could not find an instance of QueryKey for ${A}")
 @typeclass trait QueryKey[A] extends Serializable {
@@ -83,13 +81,11 @@ sealed trait QueryKeyInstances extends QueryKeyInstances1 {
 }
 
 object QueryValue extends QueryValueInstances {
-  def derive[A]: Derivation[A] = new Derivation[A](())
+  def derive[A] = new Derivation[A](())
 
   class Derivation[A](private val dummy: Unit) extends AnyVal {
-    def by[C <: Coproduct, R <: HList](
-        key: A => String
-    )(implicit gen: Generic.Aux[A, C], reify: Reify.Aux[C, R], toList: ToList[R, A]): QueryValue[A] =
-      a => toList(reify()).iterator.map(x => x -> key(x)).toMap.get(a)
+    def by[B](f: A => B)(implicit qv: QueryValue[B]): QueryValue[A] =
+      a => qv.queryValue(f(a))
   }
 
   /* ======================================================================== */
@@ -232,26 +228,27 @@ sealed trait QueryKeyValueInstances {
 }
 
 object TraversableParams extends TraversableParamsInstances {
-  implicit def field[K <: Symbol, V](implicit K: Witness.Aux[K], V: QueryValue[V]): TraversableParams[FieldType[K, V]] =
-    (a: FieldType[K, V]) => List(K.value.name -> V.queryValue(a))
+  inline def product[A](implicit m: Mirror.ProductOf[A]): TraversableParams[A] = {
+    val elemInstances = summonAll[m.MirroredElemTypes]
 
-  implicit def sub[K <: Symbol, V](implicit
-      K: Witness.Aux[K],
-      V: TraversableParams[V]
-  ): TraversableParams[FieldType[K, V]] =
-    (a: FieldType[K, V]) => V.toSeq(a)
+    new TraversableParams[A] {
+      override def toSeq(a: A): Seq[(String, Option[String])] =
+        a.asInstanceOf[Product].productElementNames
+          .zip(a.asInstanceOf[Product].productIterator)
+          .zip(elemInstances)
+          .flatMap {
+            case ((name, field), tc : QueryValue[_]) => Seq((name, tc.asInstanceOf[QueryValue[Any]].queryValue(field)))
+            case ((name, field), tc : TraversableParams[_]) => tc.asInstanceOf[TraversableParams[Any]].toSeq(field)
+          }
+          .toSeq
+    }
+  }
 
-  implicit val hnil: TraversableParams[HNil] =
-    (_: HNil) => List.empty
-
-  implicit def hcons[H, T <: HList](implicit
-      H: TraversableParams[H],
-      T: TraversableParams[T]
-  ): TraversableParams[H :: T] =
-    (a: H :: T) => H.toSeq(a.head) ++ T.toSeq(a.tail)
-
-  def product[A, R <: HList](implicit gen: LabelledGeneric.Aux[A, R], R: TraversableParams[R]): TraversableParams[A] =
-    (a: A) => R.toSeq(gen.to(a))
+  inline private def summonAll[T <: Tuple]: List[QueryValue[_] | TraversableParams[_]] =
+    inline erasedValue[T] match {
+      case _: EmptyTuple => Nil
+      case _: (t *: ts)  => summonInline[TraversableParams[t] | QueryValue[t]] :: summonAll[ts]
+    }
 
   /* ======================================================================== */
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */

--- a/shared/src/test/scala/io/lemonlabs/uri/CatsTests.scala
+++ b/shared/src/test/scala/io/lemonlabs/uri/CatsTests.scala
@@ -3,85 +3,81 @@ package io.lemonlabs.uri
 import org.scalatest.flatspec.AnyFlatSpec
 import cats.implicits._
 import org.scalatest.matchers.should.Matchers
-import cats.kernel.Comparison
+import cats.kernel.{Comparison, Eq}
 
 class CatsTests extends AnyFlatSpec with Matchers {
-  trait CatsTestCase {
-    val convertToEqualizer = () // shadow ScalaTest
-  }
-
-  "Eq" should "be supported for Uri" in new CatsTestCase {
+  "Eq" should "be supported for Uri" in {
     val uri = Uri.parse("https://typelevel.org/cats/")
     val uri2: Uri = AbsoluteUrl.parse("https://typelevel.org/cats/")
 
-    (uri === uri2) should equal(true)
+    (uri eqv uri2) should equal(true)
   }
 
-  it should "be supported for unordered query params Uri" in new CatsTestCase {
+  it should "be supported for unordered query params Uri" in {
     import Uri.unordered._
 
     val uri = Uri.parse("https://typelevel.org/cats/?a=1&b=two")
     val uri2: Uri = AbsoluteUrl.parse("https://typelevel.org/cats/?b=two&a=1")
 
-    (uri === uri2) should equal(true)
+    (uri eqv uri2) should equal(true)
   }
 
-  it should "be supported for Url" in new CatsTestCase {
+  it should "be supported for Url" in {
     val uri = Url.parse("https://typelevel.org/cats/")
     val uri2: Url = AbsoluteUrl.parse("https://typelevel.org/cats/")
 
-    (uri === uri2) should equal(true)
+    (uri eqv uri2) should equal(true)
   }
 
-  it should "be supported unordered query params Url" in new CatsTestCase {
+  it should "be supported unordered query params Url" in {
     import Url.unordered._
 
     val uri = Url.parse("https://typelevel.org/cats/?a=1&b=two")
     val uri2: Url = AbsoluteUrl.parse("https://typelevel.org/cats/?b=two&a=1")
 
-    (uri === uri2) should equal(true)
+    (uri eqv uri2) should equal(true)
   }
 
-  it should "be supported for RelativeUrl" in new CatsTestCase {
+  it should "be supported for RelativeUrl" in {
     val uri: Url = RelativeUrl.parse("/cats2/")
     val uri2: Url = RelativeUrl.parse("/cats/")
 
-    (uri === uri2) should equal(false)
+    (uri eqv uri2) should equal(false)
   }
 
-  it should "be supported for unordered query params RelativeUrl" in new CatsTestCase {
+  it should "be supported for unordered query params RelativeUrl" in {
     import RelativeUrl.unordered._
 
     val uri = RelativeUrl.parse("/cats2/?b=two&a=1")
     val uri2 = RelativeUrl.parse("/cats/?a=1&b=two")
 
-    (uri === uri2) should equal(false)
+    (uri eqv uri2) should equal(false)
   }
 
-  it should "be supported for UrlWithAuthority" in new CatsTestCase {
+  it should "be supported for UrlWithAuthority" in {
     val uri = UrlWithAuthority.parse("https://typelevel.org/cats/")
     val uri2: UrlWithAuthority = AbsoluteUrl.parse("https://typelevel.org/cats/")
 
-    (uri === uri2) should equal(true)
+    (uri eqv uri2) should equal(true)
   }
 
-  it should "be supported for unordered query params UrlWithAuthority" in new CatsTestCase {
+  it should "be supported for unordered query params UrlWithAuthority" in {
     import UrlWithAuthority.unordered._
 
     val uri = UrlWithAuthority.parse("https://typelevel.org/cats/?a=1&b=two")
     val uri2: UrlWithAuthority = AbsoluteUrl.parse("https://typelevel.org/cats/?b=two&a=1")
 
-    (uri === uri2) should equal(true)
+    (uri eqv uri2) should equal(true)
   }
 
-  it should "be supported for ProtocolRelativeUrl" in new CatsTestCase {
+  it should "be supported for ProtocolRelativeUrl" in {
     val uri = ProtocolRelativeUrl.parse("//typelevel.org/cats/")
     val uri2 = ProtocolRelativeUrl.parse("//typelevel.org/cats/?different=true")
 
     (uri =!= uri2) should equal(true)
   }
 
-  it should "be supported for unordered query params ProtocolRelativeUrl" in new CatsTestCase {
+  it should "be supported for unordered query params ProtocolRelativeUrl" in {
     import ProtocolRelativeUrl.unordered._
 
     val uri = ProtocolRelativeUrl.parse("//typelevel.org/cats/?b=two&a=1")
@@ -90,186 +86,186 @@ class CatsTests extends AnyFlatSpec with Matchers {
     (uri =!= uri2) should equal(false)
   }
 
-  it should "be supported for AbsoluteUrl" in new CatsTestCase {
+  it should "be supported for AbsoluteUrl" in {
     val uri = AbsoluteUrl.parse("https://typelevel.org/cats/")
     val uri2 = AbsoluteUrl.parse("https://typelevel.org/cats/")
 
-    (uri === uri2) should equal(true)
+    (uri eqv uri2) should equal(true)
   }
 
-  it should "be supported for unordered query params AbsoluteUrl" in new CatsTestCase {
+  it should "be supported for unordered query params AbsoluteUrl" in {
     import AbsoluteUrl.unordered._
 
     val uri = AbsoluteUrl.parse("https://typelevel.org/cats/?a=1&b=two")
     val uri2 = AbsoluteUrl.parse("https://typelevel.org/cats/?b=two&a=1")
 
-    (uri === uri2) should equal(true)
+    (uri eqv uri2) should equal(true)
   }
 
-  it should "be supported for UrlWithoutAuthority" in new CatsTestCase {
+  it should "be supported for UrlWithoutAuthority" in {
     val uri = UrlWithoutAuthority.parse("mailto:someone@somewhere.com")
     val uri2 = UrlWithoutAuthority.parse("mailto:someoneelse@somewhereelse.com")
 
-    (uri === uri2) should equal(false)
+    (uri eqv uri2) should equal(false)
   }
 
-  it should "be supported for unordered query params UrlWithoutAuthority" in new CatsTestCase {
+  it should "be supported for unordered query params UrlWithoutAuthority" in {
     import UrlWithoutAuthority.unordered._
 
     val uri = UrlWithoutAuthority.parse("mailto:someone@somewhere.com?b=two&a=1")
     val uri2 = UrlWithoutAuthority.parse("mailto:someoneelse@somewhereelse.com?a=1&b=two")
 
-    (uri === uri2) should equal(false)
+    (uri eqv uri2) should equal(false)
   }
 
-  it should "be supported for SimpleUrlWithoutAuthority" in new CatsTestCase {
+  it should "be supported for SimpleUrlWithoutAuthority" in {
     val uri = SimpleUrlWithoutAuthority.parse("mailto:someone@somewhere.com")
     val uri2 = SimpleUrlWithoutAuthority.parse("mailto:someone@somewhere.com")
 
-    (uri === uri2) should equal(true)
+    (uri eqv uri2) should equal(true)
   }
 
-  it should "be supported for unordered query params SimpleUrlWithoutAuthority" in new CatsTestCase {
+  it should "be supported for unordered query params SimpleUrlWithoutAuthority" in {
     import SimpleUrlWithoutAuthority.unordered._
 
     val uri = SimpleUrlWithoutAuthority.parse("mailto:someone@somewhere.com?a=1&b=two")
     val uri2 = SimpleUrlWithoutAuthority.parse("mailto:someone@somewhere.com?b=two&a=1")
 
-    (uri === uri2) should equal(true)
+    (uri eqv uri2) should equal(true)
   }
 
-  it should "be supported for DataUrl" in new CatsTestCase {
+  it should "be supported for DataUrl" in {
     val uri = DataUrl.parse("data:,A%20brief%20note")
     val uri2 = DataUrl.parse("data:,Another%20brief%20note")
 
     (uri =!= uri2) should equal(true)
   }
 
-  it should "be supported for ScpLikeUrl" in new CatsTestCase {
+  it should "be supported for ScpLikeUrl" in {
     val uri = ScpLikeUrl.parse("root@host:/root/file.tar.gz")
     val uri2 = ScpLikeUrl.parse("root@host:/root/file2.tar.gz")
 
     (uri =!= uri2) should equal(true)
   }
 
-  it should "be supported for Urn" in new CatsTestCase {
+  it should "be supported for Urn" in {
     val uri = Urn.parse("urn:cats:1")
     val uri2 = Urn.parse("urn:cats:2")
 
     (uri =!= uri2) should equal(true)
   }
 
-  it should "be supported for Authority" in new CatsTestCase {
+  it should "be supported for Authority" in {
     val authority = Authority.parse("typelevel.org:443")
     val authority2 = Authority.parse("typelevel.org:443")
 
-    (authority === authority2) should equal(true)
+    (authority eqv authority2) should equal(true)
   }
 
-  it should "be supported for UserInfo" in new CatsTestCase {
+  it should "be supported for UserInfo" in {
     val userInfo = UserInfo("user", "password")
     val userInfo2 = UserInfo("user", "password2")
 
     (userInfo =!= userInfo2) should equal(true)
   }
 
-  it should "be supported for Host" in new CatsTestCase {
+  it should "be supported for Host" in {
     val host = Host.parse("typelevel.org")
     val host2 = Host.parse("typelevel.org")
 
     (host =!= host2) should equal(false)
   }
 
-  it should "be supported for DomainName" in new CatsTestCase {
+  it should "be supported for DomainName" in {
     val host = DomainName.parse("typelevel.org")
     val host2 = DomainName.parse("www.typelevel.org")
 
     (host =!= host2) should equal(true)
   }
 
-  it should "be supported for Ipv4" in new CatsTestCase {
+  it should "be supported for Ipv4" in {
     val host = IpV4.parse("8.8.8.8")
     val host2 = IpV4.parse("8.8.8.8")
 
-    (host === host2) should equal(true)
+    (host eqv host2) should equal(true)
   }
 
-  it should "be supported for Ipv6" in new CatsTestCase {
+  it should "be supported for Ipv6" in {
     val host = IpV6.parse("[1f4:0:0:1e::1]")
     val host2 = IpV6.parse("[1f4:0:0:1e::1]")
 
-    (host === host2) should equal(true)
+    (host eqv host2) should equal(true)
   }
 
-  it should "be supported for MediaType" in new CatsTestCase {
+  it should "be supported for MediaType" in {
     val mediaType = MediaType("text/plain".some, Vector("charset" -> "utf8"))
     val mediaType2 = MediaType("text/plain".some, Vector.empty)
 
-    (mediaType === mediaType2) should equal(false)
+    (mediaType eqv mediaType2) should equal(false)
   }
 
-  it should "be supported for Path" in new CatsTestCase {
+  it should "be supported for Path" in {
     val path = Path.parse("/cats/")
     val path2 = Path.parse("/cats/")
 
-    (path === path2) should equal(true)
+    (path eqv path2) should equal(true)
   }
 
-  it should "be supported for UrlPath" in new CatsTestCase {
+  it should "be supported for UrlPath" in {
     val path = UrlPath.parse("/cats/")
     val path2 = UrlPath.parse("/cats/")
 
-    (path === path2) should equal(true)
+    (path eqv path2) should equal(true)
   }
 
-  it should "be supported for AbsoluteOrEmptyPath" in new CatsTestCase {
+  it should "be supported for AbsoluteOrEmptyPath" in {
     val path: AbsoluteOrEmptyPath = AbsolutePath.fromParts("cats")
     val path2: AbsoluteOrEmptyPath = AbsolutePath.fromParts("cats")
 
-    (path === path2) should equal(true)
+    (path eqv path2) should equal(true)
   }
 
-  it should "be supported for RootlessPath" in new CatsTestCase {
+  it should "be supported for RootlessPath" in {
     val path = RootlessPath.fromParts("cats")
     val path2 = RootlessPath.fromParts("cats2")
 
     (path =!= path2) should equal(true)
   }
 
-  it should "be supported for AbsolutePath" in new CatsTestCase {
+  it should "be supported for AbsolutePath" in {
     val path = AbsolutePath.fromParts("cats")
     val path2 = AbsolutePath.fromParts("cats")
 
-    (path === path2) should equal(true)
+    (path eqv path2) should equal(true)
   }
 
-  it should "be supported for UrnPath" in new CatsTestCase {
+  it should "be supported for UrnPath" in {
     val path = UrnPath.parse("cats:1")
     val path2 = UrnPath.parse("cats:2")
 
     (path =!= path2) should equal(true)
   }
 
-  it should "be supported for QueryString" in new CatsTestCase {
+  it should "be supported for QueryString" in {
     val qs = QueryString.parse("a=1&b=2")
     val qs2 = QueryString.parse("a=1&b=2")
 
-    (qs === qs2) should equal(true)
+    (qs eqv qs2) should equal(true)
   }
 
-  it should "be supported for unordered QueryString" in new CatsTestCase {
+  it should "be supported for unordered QueryString" in {
     val qs = QueryString.parse("a=1&b=2")
     val qs2 = QueryString.parse("b=2&a=1")
 
     import QueryString.unordered._
-    (qs === qs2) should equal(true)
+    (qs eqv qs2) should equal(true)
   }
 
-  it should "be supported for ordered QueryString" in new CatsTestCase {
+  it should "be supported for ordered QueryString" in {
     val qs = QueryString.parse("a=1&b=2")
     val qs2 = QueryString.parse("b=2&a=1")
 
-    (qs === qs2) should equal(false)
+    (qs eqv qs2) should equal(false)
   }
 
   "Show" should "be supported for Uri" in {
@@ -392,145 +388,145 @@ class CatsTests extends AnyFlatSpec with Matchers {
     qs.show should equal("a=1&b=2")
   }
 
-  "Order" should "be supported for Uri" in new CatsTestCase {
+  "Order" should "be supported for Uri" in {
     val uri = Uri.parse("https://typelevel.org/cats2/")
     val uri2: Uri = AbsoluteUrl.parse("https://typelevel.org/cats/")
     (uri comparison uri2) should equal(Comparison.GreaterThan)
   }
 
-  it should "be supported for Url" in new CatsTestCase {
+  it should "be supported for Url" in {
     val uri = Url.parse("https://typelevel.org/cats/")
     val uri2: Url = AbsoluteUrl.parse("https://typelevel.org/cats/")
     (uri comparison uri2) should equal(Comparison.EqualTo)
   }
 
-  it should "be supported for RelativeUrl" in new CatsTestCase {
+  it should "be supported for RelativeUrl" in {
     val uri: Url = RelativeUrl.parse("/cats2/")
     val uri2: Url = RelativeUrl.parse("/cats/")
     (uri comparison uri2) should equal(Comparison.GreaterThan)
   }
 
-  it should "be supported for UrlWithAuthority" in new CatsTestCase {
+  it should "be supported for UrlWithAuthority" in {
     val uri = UrlWithAuthority.parse("https://typelevel.org/cats/")
     val uri2: UrlWithAuthority = AbsoluteUrl.parse("https://typelevel.org/cats/")
     (uri comparison uri2) should equal(Comparison.EqualTo)
   }
 
-  it should "be supported for ProtocolRelativeUrl" in new CatsTestCase {
+  it should "be supported for ProtocolRelativeUrl" in {
     val uri = ProtocolRelativeUrl.parse("//typelevel.org/cats/")
     val uri2 = ProtocolRelativeUrl.parse("//typelevel.org/cats/?different=true")
     (uri comparison uri2) should equal(Comparison.LessThan)
   }
 
-  it should "be supported for AbsoluteUrl" in new CatsTestCase {
+  it should "be supported for AbsoluteUrl" in {
     val uri = AbsoluteUrl.parse("https://typelevel.org/cats/")
     val uri2 = AbsoluteUrl.parse("https://typelevel.org/cats/")
     (uri comparison uri2) should equal(Comparison.EqualTo)
   }
 
-  it should "be supported for UrlWithoutAuthority" in new CatsTestCase {
+  it should "be supported for UrlWithoutAuthority" in {
     val uri = UrlWithoutAuthority.parse("mailto:someone@somewhere.com")
     val uri2 = UrlWithoutAuthority.parse("mailto:someoneelse@somewhereelse.com")
     (uri comparison uri2) should equal(Comparison.LessThan)
   }
 
-  it should "be supported for SimpleUrlWithoutAuthority" in new CatsTestCase {
+  it should "be supported for SimpleUrlWithoutAuthority" in {
     val uri = SimpleUrlWithoutAuthority.parse("mailto:someone@somewhere.com")
     val uri2 = SimpleUrlWithoutAuthority.parse("mailto:someone@somewhere.com")
     (uri comparison uri2) should equal(Comparison.EqualTo)
   }
 
-  it should "be supported for DataUrl" in new CatsTestCase {
+  it should "be supported for DataUrl" in {
     val uri = DataUrl.parse("data:text;,A%20brief%20note")
     val uri2 = DataUrl.parse("data:text;base64,R0lGODdh")
     (uri comparison uri2) should equal(Comparison.LessThan)
   }
 
-  "Order" should "be supported for Urn" in new CatsTestCase {
+  "Order" should "be supported for Urn" in {
     val uri = Urn.parse("urn:cats:1")
     val uri2 = Urn.parse("urn:cats:2")
     (uri comparison uri2) should equal(Comparison.LessThan)
   }
 
-  it should "be supported for Authority" in new CatsTestCase {
+  it should "be supported for Authority" in {
     val authority = Authority.parse("typelevel.org:443")
     val authority2 = Authority.parse("typelevel.org:443")
     (authority comparison authority2) should equal(Comparison.EqualTo)
   }
 
-  it should "be supported for UserInfo" in new CatsTestCase {
+  it should "be supported for UserInfo" in {
     val userInfo = UserInfo("user", "password")
     val userInfo2 = UserInfo("user", "password2")
     (userInfo comparison userInfo2) should equal(Comparison.LessThan)
   }
 
-  it should "be supported for Host" in new CatsTestCase {
+  it should "be supported for Host" in {
     val host = Host.parse("typelevel.org")
     val host2 = Host.parse("typelevel.org")
     (host comparison host2) should equal(Comparison.EqualTo)
   }
 
-  it should "be supported for DomainName" in new CatsTestCase {
+  it should "be supported for DomainName" in {
     val host = DomainName.parse("typelevel.org")
     val host2 = DomainName.parse("www.typelevel.org")
     (host comparison host2) should equal(Comparison.LessThan)
   }
 
-  it should "be supported for Ipv4" in new CatsTestCase {
+  it should "be supported for Ipv4" in {
     val host = IpV4.parse("8.8.8.8")
     val host2 = IpV4.parse("8.8.8.8")
     (host comparison host2) should equal(Comparison.EqualTo)
   }
 
-  it should "be supported for Ipv6" in new CatsTestCase {
+  it should "be supported for Ipv6" in {
     val host = IpV6.parse("[1f4:0:0:1e::1]")
     val host2 = IpV6.parse("[1f4:0:0:1e::1]")
     (host comparison host2) should equal(Comparison.EqualTo)
   }
 
-  it should "be supported for MediaType" in new CatsTestCase {
+  it should "be supported for MediaType" in {
     val mediaType = MediaType("text/plain".some, Vector("charset" -> "utf8"))
     val mediaType2 = MediaType("text/plain".some, Vector.empty)
     (mediaType comparison mediaType2) should equal(Comparison.GreaterThan)
   }
 
-  it should "be supported for Path" in new CatsTestCase {
+  it should "be supported for Path" in {
     val path = Path.parse("/cats/")
     val path2 = Path.parse("/cats/")
     (path comparison path2) should equal(Comparison.EqualTo)
   }
 
-  it should "be supported for UrlPath" in new CatsTestCase {
+  it should "be supported for UrlPath" in {
     val path = UrlPath.parse("/cats/")
     val path2 = UrlPath.parse("/cats/")
     (path comparison path2) should equal(Comparison.EqualTo)
   }
 
-  it should "be supported for AbsoluteOrEmptyPath" in new CatsTestCase {
+  it should "be supported for AbsoluteOrEmptyPath" in {
     val path: AbsoluteOrEmptyPath = AbsolutePath.fromParts("cats")
     val path2: AbsoluteOrEmptyPath = AbsolutePath.fromParts("cats")
     (path comparison path2) should equal(Comparison.EqualTo)
   }
 
-  it should "be supported for RootlessPath" in new CatsTestCase {
+  it should "be supported for RootlessPath" in {
     val path = RootlessPath.fromParts("cats")
     val path2 = RootlessPath.fromParts("cats2")
     (path comparison path2) should equal(Comparison.LessThan)
   }
 
-  it should "be supported for AbsolutePath" in new CatsTestCase {
+  it should "be supported for AbsolutePath" in {
     val path = AbsolutePath.fromParts("cats")
     val path2 = AbsolutePath.fromParts("cats")
     (path comparison path2) should equal(Comparison.EqualTo)
   }
 
-  it should "be supported for UrnPath" in new CatsTestCase {
+  it should "be supported for UrnPath" in {
     val path = UrnPath.parse("cats:1")
     val path2 = UrnPath.parse("cats:2")
     (path comparison path2) should equal(Comparison.LessThan)
   }
 
-  it should "be supported for QueryString" in new CatsTestCase {
+  it should "be supported for QueryString" in {
     val qs = QueryString.parse("a=1&b=2")
     val qs2 = QueryString.parse("a=1&b=2")
     (qs comparison qs2) should equal(Comparison.EqualTo)

--- a/shared/src/test/scala/io/lemonlabs/uri/ConfigTests.scala
+++ b/shared/src/test/scala/io/lemonlabs/uri/ConfigTests.scala
@@ -14,7 +14,7 @@ import org.scalatest.matchers.should.Matchers
 
 class ConfigTests extends AnyFlatSpec with Matchers {
   "Config constructor without defaultPorts" should "use the default defaultPorts" in {
-    val conf = new UriConfig(
+    val conf = UriConfig(
       userInfoEncoder = PercentEncoder(USER_INFO_CHARS_TO_ENCODE),
       pathEncoder = PercentEncoder(PATH_CHARS_TO_ENCODE),
       queryEncoder = PercentEncoder(QUERY_CHARS_TO_ENCODE),

--- a/shared/src/test/scala/io/lemonlabs/uri/EqualityTests.scala
+++ b/shared/src/test/scala/io/lemonlabs/uri/EqualityTests.scala
@@ -96,7 +96,7 @@ class EqualityTests extends AnyFlatSpec with Matchers with ScalaCheckDrivenPrope
   }
 
   "DataUrl.equals" should "equal itself" in new UriScalaCheckGenerators {
-    forAll { dataUrl: DataUrl =>
+    forAll { (dataUrl: DataUrl) =>
       (dataUrl == dataUrl) should equal(true)
     }
   }
@@ -108,7 +108,7 @@ class EqualityTests extends AnyFlatSpec with Matchers with ScalaCheckDrivenPrope
   }
 
   "DataUrl.hashCode" should "equal itself" in new UriScalaCheckGenerators {
-    forAll { dataUrl: DataUrl =>
+    forAll { (dataUrl: DataUrl) =>
       dataUrl.hashCode() should equal(dataUrl.hashCode())
     }
   }

--- a/shared/src/test/scala/io/lemonlabs/uri/TypeClassTests.scala
+++ b/shared/src/test/scala/io/lemonlabs/uri/TypeClassTests.scala
@@ -62,8 +62,7 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
   "Foo" should "render correctly as path part" in {
     final case class Foo(a: String, b: Int)
     object Foo {
-      implicit val pathPart: TraversablePathParts[Foo] =
-        TraversablePathParts.product
+      given pathPart: TraversablePathParts[Foo] = TraversablePathParts.product
     }
 
     val uri = Url.parse("http://example.com") addPathParts Foo(a = "user", b = 1)
@@ -73,7 +72,7 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
   "Foo" should "render correctly as fragment" in {
     final case class Foo(a: String, b: Int)
     object Foo {
-      implicit val pathPart: Fragment[Foo] = (foo: Foo) => Some(s"${foo.a}-${foo.b}")
+      given pathPart: Fragment[Foo] = (foo: Foo) => Some(s"${foo.a}-${foo.b}")
     }
 
     val uri = Url.parse("/uris-in-scala.html") withFragment Foo(a = "user", b = 1)
@@ -83,7 +82,7 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
   "Foo" should "render correctly as query parameters" in {
     final case class Foo(a: String)
     object Foo {
-      implicit val fooQueryKeyValue: QueryKeyValue[Foo] = QueryKeyValue(_ => "foo", foo => Option(foo.a))
+      given fooQueryKeyValue: QueryKeyValue[Foo] = QueryKeyValue(_ => "foo", foo => Option(foo.a))
     }
 
     val uri = Url.parse("/uris-in-scala.html") addParam Foo("foo_value")
@@ -94,7 +93,7 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
     final case class Foo(a: Int, b: String)
 
     object Foo {
-      implicit val traversablePathParts: TraversablePathParts[Foo] = TraversablePathParts.product
+      given traversablePathParts: TraversablePathParts[Foo] = TraversablePathParts.product
     }
 
     val uri = Url.parse("/uris-in-scala") addPathParts Foo(a = 1, b = "bar")
@@ -105,13 +104,13 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
     final case class Foo(a: Int, b: String)
 
     object Foo {
-      implicit val traversablePathParts: TraversablePathParts[Foo] = TraversablePathParts.product
+      given traversablePathParts: TraversablePathParts[Foo] = TraversablePathParts.product
     }
 
     final case class Bar(c: Int, foo: Foo)
 
     object Bar {
-      implicit val traversablePathParts: TraversablePathParts[Bar] = TraversablePathParts.product
+      given traversablePathParts: TraversablePathParts[Bar] = TraversablePathParts.product
     }
 
     val uri = Url.parse("/uris-in-scala") addPathParts Bar(c = 2, foo = Foo(a = 1, b = "bar"))
@@ -122,7 +121,7 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
     final case class Foo(a: Int, b: Option[String])
 
     object Foo {
-      implicit val traversablePathParts: TraversablePathParts[Foo] = TraversablePathParts.product
+      given traversablePathParts: TraversablePathParts[Foo] = TraversablePathParts.product
     }
 
     val uriWithB = Url.parse("/uris-in-scala") addPathParts Foo(a = 1, b = Some("bar"))
@@ -135,7 +134,7 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
     final case class Foo(a: Int, b: String)
 
     object Foo {
-      implicit val traversablePathParts: TraversablePathParts[Foo] = TraversablePathParts.product
+      given traversablePathParts: TraversablePathParts[Foo] = TraversablePathParts.product
     }
 
     val uri = Url.parse("/uris-in-scala") withPathParts Foo(a = 1, b = "bar")
@@ -146,13 +145,13 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
     final case class Foo(a: Int, b: String)
 
     object Foo {
-      implicit val traversablePathParts: TraversablePathParts[Foo] = TraversablePathParts.product
+      given traversablePathParts: TraversablePathParts[Foo] = TraversablePathParts.product
     }
 
     final case class Bar(c: Int, foo: Foo)
 
     object Bar {
-      implicit val traversablePathParts: TraversablePathParts[Bar] = TraversablePathParts.product
+      given traversablePathParts: TraversablePathParts[Bar] = TraversablePathParts.product
     }
 
     val uri = Url.parse("/uris-in-scala") withPathParts Bar(c = 2, foo = Foo(a = 1, b = "bar"))
@@ -163,7 +162,7 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
     final case class Foo(a: Int, b: Option[String])
 
     object Foo {
-      implicit val traversablePathParts: TraversablePathParts[Foo] = TraversablePathParts.product
+      given traversablePathParts: TraversablePathParts[Foo] = TraversablePathParts.product
     }
 
     val uriWithB = Url.parse("/uris-in-scala") withPathParts Foo(a = 1, b = Some("bar"))
@@ -201,7 +200,7 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
     final case class Foo(a: Int, b: String)
 
     object Foo {
-      implicit val traversableParams: TraversableParams[Foo] = TraversableParams.product
+      given traversableParams: TraversableParams[Foo] = TraversableParams.product
     }
 
     val uri = Url.parse("/uris-in-scala.html") addParams Foo(a = 1, b = "bar")
@@ -212,13 +211,13 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
     final case class Foo(a: Int, b: String)
 
     object Foo {
-      implicit val traversableParams: TraversableParams[Foo] = TraversableParams.product
+      given traversableParams: TraversableParams[Foo] = TraversableParams.product
     }
 
     final case class Bar(c: Int, foo: Foo)
 
     object Bar {
-      implicit val traversableParams: TraversableParams[Bar] = TraversableParams.product
+      given traversableParams: TraversableParams[Bar] = TraversableParams.product
     }
 
     val uri = Url.parse("/uris-in-scala.html") addParams Bar(c = 2, foo = Foo(a = 1, b = "bar"))
@@ -229,7 +228,7 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
     final case class Foo(a: Int, b: Option[String])
 
     object Foo {
-      implicit val traversableParams: TraversableParams[Foo] = TraversableParams.product
+      given traversableParams: TraversableParams[Foo] = TraversableParams.product
     }
 
     val uriWithB = Url.parse("/uris-in-scala.html") addParams Foo(a = 1, b = Some("bar"))
@@ -238,7 +237,7 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
     uriWithoutB.toString should equal("/uris-in-scala.html?a=1&b")
 
     {
-      implicit val config: UriConfig = UriConfig(renderQuery = ExcludeNones)
+      given config: UriConfig = UriConfig(renderQuery = ExcludeNones)
       val uriWithBexludingNones = Url.parse("/uris-in-scala.html") addParams Foo(a = 1, b = Some("bar"))
       val uriWithoutBexludingNones = Url.parse("/uris-in-scala.html") addParams Foo(a = 1, b = None)
       uriWithBexludingNones.toString should equal("/uris-in-scala.html?a=1&b=bar")
@@ -260,7 +259,7 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
     }
 
     object Foo {
-      implicit val queryValue: QueryValue[Foo] = QueryValue.derive[Foo].by(_.name)
+      given queryValue: QueryValue[Foo] = QueryValue.derive[Foo].by(_.name)
     }
 
     val uriA = Url.parse("/uris-in-scala.html") addParam ("foo" -> A)

--- a/shared/src/test/scala/io/lemonlabs/uri/TypesafeDslTypeTests.scala
+++ b/shared/src/test/scala/io/lemonlabs/uri/TypesafeDslTypeTests.scala
@@ -2,8 +2,6 @@ package io.lemonlabs.uri
 
 import io.lemonlabs.uri.config.{ExcludeNones, UriConfig}
 import io.lemonlabs.uri.typesafe._
-import shapeless._
-import shapeless.labelled._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -38,7 +36,7 @@ class TypesafeDslTypeTests extends AnyFlatSpec with Matchers {
   "Foo" should "render correctly as path part" in {
     final case class Foo(a: String, b: Int)
     object Foo {
-      implicit val pathPart: TraversablePathParts[Foo] =
+      given pathPart: TraversablePathParts[Foo] =
         TraversablePathParts.product
     }
 
@@ -70,7 +68,7 @@ class TypesafeDslTypeTests extends AnyFlatSpec with Matchers {
     final case class Foo(a: Int, b: String)
 
     object Foo {
-      implicit val traversableParams: TraversableParams[Foo] = TraversableParams.product
+      given traversableParams: TraversableParams[Foo] = TraversableParams.product
     }
 
     val uri = "/uris-in-scala.html" addParams Foo(a = 1, b = "bar")
@@ -81,13 +79,13 @@ class TypesafeDslTypeTests extends AnyFlatSpec with Matchers {
     final case class Foo(a: Int, b: String)
 
     object Foo {
-      implicit val traversableParams: TraversableParams[Foo] = TraversableParams.product
+      given traversableParams: TraversableParams[Foo] = TraversableParams.product
     }
 
     final case class Bar(c: Int, foo: Foo)
 
     object Bar {
-      implicit val traversableParams: TraversableParams[Bar] = TraversableParams.product
+      given traversableParams: TraversableParams[Bar] = TraversableParams.product
     }
 
     val uri = "/uris-in-scala.html" addParams Bar(c = 2, foo = Foo(a = 1, b = "bar"))
@@ -98,7 +96,7 @@ class TypesafeDslTypeTests extends AnyFlatSpec with Matchers {
     final case class Foo(a: Int, b: Option[String])
 
     object Foo {
-      implicit val traversableParams: TraversableParams[Foo] = TraversableParams.product
+      given traversableParams: TraversableParams[Foo] = TraversableParams.product
     }
 
     val uriWithB = "/uris-in-scala.html" addParams Foo(a = 1, b = Some("bar"))

--- a/shared/src/test/scala/io/lemonlabs/uri/UriScalaCheckGenerators.scala
+++ b/shared/src/test/scala/io/lemonlabs/uri/UriScalaCheckGenerators.scala
@@ -86,9 +86,9 @@ trait UriScalaCheckGenerators {
   // format: off
 
   implicit val randIpV6:Arbitrary[IpV6] =  {
-    val piece = Gen.chooseNum(0, Char.MaxValue)
+    val piece = Gen.chooseNum[Int](0, Char.MaxValue)
     Arbitrary(Gen.zip(piece, piece, piece, piece, piece, piece, piece, piece).map {
-      case (a, b, c, d, e, f, g, h) => IpV6(a, b, c, d, e, f, g, h)
+      case (a, b, c, d, e, f, g, h) => IpV6.apply(a, b, c, d, e, f, g, h)
     })
   }
 


### PR DESCRIPTION
Hi @theon, 

I've continued your branch towards scala 3. Please note that the PR target is the branch **scala3** instead of master.

I've removed the shapeless dependency by migrating to [scala 3 type class derivation](https://dotty.epfl.ch/docs/reference/contextual/derivation.html). The tests are green on my local maschine.

I had to disable scalafmt, as it could not parse the type class derivation code. 

