### PR TITLE
scala version specific source directories

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,5 @@
-version = 2.7.5
+version = 3.0.3
+runner.dialect = Scala3
 
 align.tokens              = [
   {code = "=>",  owner = "Case"},
@@ -11,7 +12,8 @@ project.excludeFilters = [
   "shared/src/main/scala/io/lemonlabs/uri/inet/PublicSuffixTrie.scala"
 ]
 align.openParenDefnSite    = true
-docstrings                 = ScalaDoc
+docstrings.style           = SpaceAsterisk
+docstrings.wrap            = no
 maxColumn                  = 120
 rewrite.rules              = [RedundantParens, SortImports]
 newlines.afterCurlyLambda  = preserve

--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ Only percent encode the hash character:
 import io.lemonlabs.uri.config.UriConfig
 import io.lemonlabs.uri.encoding._
 
-implicit val config = UriConfig(encoder = percentEncode('#'))
+implicit val config: UriConfig = UriConfig(encoder = percentEncode('#'))
 ```
 
 Percent encode all the default chars, except the plus character:
@@ -404,7 +404,7 @@ Percent encode all the default chars, except the plus character:
 import io.lemonlabs.uri.config.UriConfig
 import io.lemonlabs.uri.encoding._
 
-implicit val config = UriConfig(encoder = percentEncode -- '+')
+implicit val config: UriConfig = UriConfig(encoder = percentEncode -- '+')
 ```
 
 Encode all the default chars, and also encode the letters a and b:
@@ -413,7 +413,7 @@ Encode all the default chars, and also encode the letters a and b:
 import io.lemonlabs.uri.config.UriConfig
 import io.lemonlabs.uri.encoding._
 
-implicit val config = UriConfig(encoder = percentEncode ++ ('a', 'b'))
+implicit val config: UriConfig = UriConfig(encoder = percentEncode ++ ('a', 'b'))
 ```
 
 ### Encoding spaces as pluses
@@ -428,7 +428,7 @@ import io.lemonlabs.uri.config.UriConfig
 import io.lemonlabs.uri.encoding._
 import io.lemonlabs.uri.encoding.PercentEncoder._
 
-implicit val config = UriConfig.default.copy(queryEncoder = PercentEncoder())
+implicit val config: UriConfig = UriConfig.default.copy(queryEncoder = PercentEncoder())
 
 val uri = Url.parse("http://theon.github.com?test=uri with space")
 uri.toString // This is http://theon.github.com?test=uri%20with%20space
@@ -443,7 +443,7 @@ import io.lemonlabs.uri.Url
 import io.lemonlabs.uri.config.UriConfig
 import io.lemonlabs.uri.decoding._
 
-implicit val config = UriConfig.default.copy(queryDecoder = PercentDecoder)
+implicit val config: UriConfig = UriConfig.default.copy(queryDecoder = PercentDecoder)
 
 val uri = Url.parse("http://theon.github.com?test=uri+with+plus")
 uri.query.param("test") // This is Some("uri+with+plus")
@@ -458,7 +458,7 @@ import io.lemonlabs.uri.Url
 import io.lemonlabs.uri.config.UriConfig
 import io.lemonlabs.uri.encoding._
 
-implicit val config = UriConfig(encoder = percentEncode + encodeCharAs(' ', "_"))
+implicit val config: UriConfig = UriConfig(encoder = percentEncode + encodeCharAs(' ', "_"))
 
 val uri = Url.parse("http://theon.github.com/uri with space")
 uri.toString // This is http://theon.github.com/uri_with_space
@@ -484,7 +484,7 @@ import io.lemonlabs.uri.Url
 import io.lemonlabs.uri.config.UriConfig
 import io.lemonlabs.uri.decoding.NoopDecoder
 
-implicit val c = UriConfig(decoder = NoopDecoder)
+implicit val c: UriConfig = UriConfig(decoder = NoopDecoder)
 
 val uri = Url.parse("http://example.com/i-havent-%been%-percent-encoded")
 
@@ -507,7 +507,7 @@ import io.lemonlabs.uri.Url
 import io.lemonlabs.uri.config.UriConfig
 import io.lemonlabs.uri.decoding.PercentDecoder
 
-implicit val c = UriConfig(
+implicit val c: UriConfig = UriConfig(
   decoder = PercentDecoder(ignoreInvalidPercentEncoding = true)
 )
 val uri = Url.parse("/?x=%3")
@@ -638,7 +638,7 @@ This can be changed like so:
 import io.lemonlabs.uri.config.UriConfig
 import io.lemonlabs.uri.Url
 
-implicit val conf = UriConfig(charset = "GB2312")
+implicit val conf: UriConfig = UriConfig(charset = "GB2312")
 
 val uri = Url.parse("http://theon.github.com/uris-in-scala.html?chinese=网址")
 uri.toString // This is http://theon.github.com/uris-in-scala.html?chinese=%CD%F8%D6%B7

--- a/build.sbt
+++ b/build.sbt
@@ -20,6 +20,10 @@ publish / skip                 := true // Do not publish the root project
 val simulacrumScalafixVersion = "0.5.4"
 ThisBuild / scalafixDependencies += "org.typelevel" %% "simulacrum-scalafix" % simulacrumScalafixVersion
 
+val isScala3 = Def.setting {
+  CrossVersion.partialVersion(scalaVersion.value).exists(_._1 != 2)
+}
+
 val sharedSettings = Seq(
   organization := "io.lemonlabs",
   libraryDependencies ++= Seq(
@@ -67,6 +71,7 @@ val scalaUriSettings = Seq(
     "org.typelevel" %%% "cats-core"  % "2.6.1",
     "org.typelevel" %%% "cats-parse" % "0.3.4"
   ),
+  libraryDependencies ++= (if (isScala3.value) Nil else Seq("com.chuusai" %%% "shapeless" % "2.3.7")),
   pomPostProcess := { node =>
     new RuleTransformer(new RewriteRule {
       override def transform(node: xml.Node): Seq[xml.Node] = {

--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ val sharedSettings = Seq(
     "-language:higherKinds,implicitConversions"
   ) ++ (
     VersionNumber(scalaVersion.value) match {
-      case v if v.matchesSemVer(SemanticSelector("=2.13")) => Seq("-Ymacro-annotations")
+      case v if v.matchesSemVer(SemanticSelector("=2.13"))  => Seq("-Ymacro-annotations")
       case v if v.matchesSemVer(SemanticSelector("<=2.12")) => Seq("-Ypartial-unification")
       case _                                                => Nil
     }
@@ -52,7 +52,7 @@ val sharedSettings = Seq(
 //  addCompilerPlugin(scalafixSemanticdb),
 //  scalacOptions ++= Seq(s"-P:semanticdb:targetroot:${baseDirectory.value}/target/.semanticdb", "-Yrangepos"),
   Test / parallelExecution := false,
-//  scalafmtOnCompile        := true,
+  scalafmtOnCompile        := true,
   coverageExcludedPackages := "(io.lemonlabs.uri.inet.Trie.*|io.lemonlabs.uri.inet.PublicSuffixes.*|io.lemonlabs.uri.inet.PublicSuffixTrie.*|io.lemonlabs.uri.inet.PunycodeSupport.*)"
 )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,6 +10,6 @@ addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.0.0")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.3")
 
-addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.22")
+addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.23")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.30")

--- a/shared/src/main/scala-2/io/lemonlabs/uri/typesafe/TraversableParamsDeriving.scala
+++ b/shared/src/main/scala-2/io/lemonlabs/uri/typesafe/TraversableParamsDeriving.scala
@@ -1,0 +1,30 @@
+package io.lemonlabs.uri.typesafe
+
+import cats.syntax.contravariant._
+import shapeless._
+import shapeless.labelled._
+import shapeless.ops.coproduct.Reify
+import shapeless.ops.hlist.ToList
+
+trait TraversableParamsDeriving {
+  implicit def field[K <: Symbol, V](implicit K: Witness.Aux[K], V: QueryValue[V]): TraversableParams[FieldType[K, V]] =
+    (a: FieldType[K, V]) => List(K.value.name -> V.queryValue(a))
+
+  implicit def sub[K <: Symbol, V](implicit
+                                   K: Witness.Aux[K],
+                                   V: TraversableParams[V]
+                                  ): TraversableParams[FieldType[K, V]] =
+    (a: FieldType[K, V]) => V.toSeq(a)
+
+  implicit val hnil: TraversableParams[HNil] =
+    (_: HNil) => List.empty
+
+  implicit def hcons[H, T <: HList](implicit
+                                    H: TraversableParams[H],
+                                    T: TraversableParams[T]
+                                   ): TraversableParams[H :: T] =
+    (a: H :: T) => H.toSeq(a.head) ++ T.toSeq(a.tail)
+
+  def product[A, R <: HList](implicit gen: LabelledGeneric.Aux[A, R], R: TraversableParams[R]): TraversableParams[A] =
+    (a: A) => R.toSeq(gen.to(a))
+}

--- a/shared/src/main/scala-2/io/lemonlabs/uri/typesafe/TraversableParamsDeriving.scala
+++ b/shared/src/main/scala-2/io/lemonlabs/uri/typesafe/TraversableParamsDeriving.scala
@@ -11,18 +11,18 @@ trait TraversableParamsDeriving {
     (a: FieldType[K, V]) => List(K.value.name -> V.queryValue(a))
 
   implicit def sub[K <: Symbol, V](implicit
-                                   K: Witness.Aux[K],
-                                   V: TraversableParams[V]
-                                  ): TraversableParams[FieldType[K, V]] =
+      K: Witness.Aux[K],
+      V: TraversableParams[V]
+  ): TraversableParams[FieldType[K, V]] =
     (a: FieldType[K, V]) => V.toSeq(a)
 
   implicit val hnil: TraversableParams[HNil] =
     (_: HNil) => List.empty
 
   implicit def hcons[H, T <: HList](implicit
-                                    H: TraversableParams[H],
-                                    T: TraversableParams[T]
-                                   ): TraversableParams[H :: T] =
+      H: TraversableParams[H],
+      T: TraversableParams[T]
+  ): TraversableParams[H :: T] =
     (a: H :: T) => H.toSeq(a.head) ++ T.toSeq(a.tail)
 
   def product[A, R <: HList](implicit gen: LabelledGeneric.Aux[A, R], R: TraversableParams[R]): TraversableParams[A] =

--- a/shared/src/main/scala-2/io/lemonlabs/uri/typesafe/TraversablePathPartsDeriving.scala
+++ b/shared/src/main/scala-2/io/lemonlabs/uri/typesafe/TraversablePathPartsDeriving.scala
@@ -6,24 +6,24 @@ import shapeless.labelled._
 
 trait TraversablePathPartsDeriving {
   implicit def field[K <: Symbol, V](implicit
-                                     K: Witness.Aux[K],
-                                     V: PathPart[V]
-                                    ): TraversablePathParts[FieldType[K, V]] =
+      K: Witness.Aux[K],
+      V: PathPart[V]
+  ): TraversablePathParts[FieldType[K, V]] =
     (a: FieldType[K, V]) => V.splitPath(a)
 
   implicit def sub[K <: Symbol, V](implicit
-                                   K: Witness.Aux[K],
-                                   V: TraversablePathParts[V]
-                                  ): TraversablePathParts[FieldType[K, V]] =
+      K: Witness.Aux[K],
+      V: TraversablePathParts[V]
+  ): TraversablePathParts[FieldType[K, V]] =
     (a: FieldType[K, V]) => V.toSeq(a)
 
   implicit val hnil: TraversablePathParts[HNil] =
     (_: HNil) => Seq.empty
 
   implicit def hcons[H, T <: HList](implicit
-                                    H: TraversablePathParts[H],
-                                    T: TraversablePathParts[T]
-                                   ): TraversablePathParts[H :: T] =
+      H: TraversablePathParts[H],
+      T: TraversablePathParts[T]
+  ): TraversablePathParts[H :: T] =
     (a: H :: T) => H.toSeq(a.head) ++ T.toSeq(a.tail)
 
   def product[A, R <: HList](implicit gen: Generic.Aux[A, R], R: TraversablePathParts[R]): TraversablePathParts[A] =

--- a/shared/src/main/scala-2/io/lemonlabs/uri/typesafe/TraversablePathPartsDeriving.scala
+++ b/shared/src/main/scala-2/io/lemonlabs/uri/typesafe/TraversablePathPartsDeriving.scala
@@ -1,0 +1,31 @@
+package io.lemonlabs.uri.typesafe
+
+import cats.syntax.contravariant._
+import shapeless._
+import shapeless.labelled._
+
+trait TraversablePathPartsDeriving {
+  implicit def field[K <: Symbol, V](implicit
+                                     K: Witness.Aux[K],
+                                     V: PathPart[V]
+                                    ): TraversablePathParts[FieldType[K, V]] =
+    (a: FieldType[K, V]) => V.splitPath(a)
+
+  implicit def sub[K <: Symbol, V](implicit
+                                   K: Witness.Aux[K],
+                                   V: TraversablePathParts[V]
+                                  ): TraversablePathParts[FieldType[K, V]] =
+    (a: FieldType[K, V]) => V.toSeq(a)
+
+  implicit val hnil: TraversablePathParts[HNil] =
+    (_: HNil) => Seq.empty
+
+  implicit def hcons[H, T <: HList](implicit
+                                    H: TraversablePathParts[H],
+                                    T: TraversablePathParts[T]
+                                   ): TraversablePathParts[H :: T] =
+    (a: H :: T) => H.toSeq(a.head) ++ T.toSeq(a.tail)
+
+  def product[A, R <: HList](implicit gen: Generic.Aux[A, R], R: TraversablePathParts[R]): TraversablePathParts[A] =
+    (a: A) => R.toSeq(gen.to(a))
+}

--- a/shared/src/main/scala-3/io/lemonlabs/uri/typesafe /TraversableParamsDeriving.scala
+++ b/shared/src/main/scala-3/io/lemonlabs/uri/typesafe /TraversableParamsDeriving.scala
@@ -1,0 +1,28 @@
+package io.lemonlabs.uri.typesafe
+
+import scala.compiletime.{erasedValue, summonInline}
+import scala.deriving.Mirror
+
+trait TraversableParamsDeriving {
+  inline def product[A](implicit m: Mirror.ProductOf[A]): TraversableParams[A] = {
+    val elemInstances = summonAll[m.MirroredElemTypes]
+
+    new TraversableParams[A] {
+      override def toSeq(a: A): Seq[(String, Option[String])] =
+        a.asInstanceOf[Product].productElementNames
+          .zip(a.asInstanceOf[Product].productIterator)
+          .zip(elemInstances)
+          .flatMap {
+            case ((name, field), tc : QueryValue[_]) => Seq((name, tc.asInstanceOf[QueryValue[Any]].queryValue(field)))
+            case ((name, field), tc : TraversableParams[_]) => tc.asInstanceOf[TraversableParams[Any]].toSeq(field)
+          }
+          .toSeq
+    }
+  }
+
+  inline def summonAll[T <: Tuple]: List[QueryValue[_] | TraversableParams[_]] =
+    inline erasedValue[T] match {
+      case _: EmptyTuple => Nil
+      case _: (t *: ts)  => summonInline[TraversableParams[t] | QueryValue[t]] :: summonAll[ts]
+    }
+}

--- a/shared/src/main/scala-3/io/lemonlabs/uri/typesafe /TraversableParamsDeriving.scala
+++ b/shared/src/main/scala-3/io/lemonlabs/uri/typesafe /TraversableParamsDeriving.scala
@@ -9,12 +9,13 @@ trait TraversableParamsDeriving {
 
     new TraversableParams[A] {
       override def toSeq(a: A): Seq[(String, Option[String])] =
-        a.asInstanceOf[Product].productElementNames
+        a.asInstanceOf[Product]
+          .productElementNames
           .zip(a.asInstanceOf[Product].productIterator)
           .zip(elemInstances)
           .flatMap {
-            case ((name, field), tc : QueryValue[_]) => Seq((name, tc.asInstanceOf[QueryValue[Any]].queryValue(field)))
-            case ((name, field), tc : TraversableParams[_]) => tc.asInstanceOf[TraversableParams[Any]].toSeq(field)
+            case ((name, field), tc: QueryValue[_]) => Seq((name, tc.asInstanceOf[QueryValue[Any]].queryValue(field)))
+            case ((name, field), tc: TraversableParams[_]) => tc.asInstanceOf[TraversableParams[Any]].toSeq(field)
           }
           .toSeq
     }

--- a/shared/src/main/scala-3/io/lemonlabs/uri/typesafe /TraversablePathPartsDeriving.scala
+++ b/shared/src/main/scala-3/io/lemonlabs/uri/typesafe /TraversablePathPartsDeriving.scala
@@ -9,7 +9,9 @@ trait TraversablePathPartsDeriving {
 
     new TraversablePathParts[A] {
       override def toSeq(a: A): Seq[String] =
-        a.asInstanceOf[Product].productIterator.zip(elemInstances)
+        a.asInstanceOf[Product]
+          .productIterator
+          .zip(elemInstances)
           .flatMap { case (field, tc) => tc.asInstanceOf[TraversablePathParts[Any]].toSeq(field) }
           .toSeq
     }

--- a/shared/src/main/scala-3/io/lemonlabs/uri/typesafe /TraversablePathPartsDeriving.scala
+++ b/shared/src/main/scala-3/io/lemonlabs/uri/typesafe /TraversablePathPartsDeriving.scala
@@ -1,0 +1,23 @@
+package io.lemonlabs.uri.typesafe
+
+import scala.compiletime.{erasedValue, summonInline}
+import scala.deriving.Mirror
+
+trait TraversablePathPartsDeriving {
+  inline def product[A](implicit m: Mirror.ProductOf[A]): TraversablePathParts[A] = {
+    val elemInstances = summonAll[m.MirroredElemTypes]
+
+    new TraversablePathParts[A] {
+      override def toSeq(a: A): Seq[String] =
+        a.asInstanceOf[Product].productIterator.zip(elemInstances)
+          .flatMap { case (field, tc) => tc.asInstanceOf[TraversablePathParts[Any]].toSeq(field) }
+          .toSeq
+    }
+  }
+
+  inline def summonAll[T <: Tuple]: List[TraversablePathParts[_]] =
+    inline erasedValue[T] match {
+      case _: EmptyTuple => Nil
+      case _: (t *: ts)  => summonInline[TraversablePathParts[t]] :: summonAll[ts]
+    }
+}

--- a/shared/src/main/scala/io/lemonlabs/uri/Uri.scala
+++ b/shared/src/main/scala/io/lemonlabs/uri/Uri.scala
@@ -455,7 +455,7 @@ sealed trait Url extends Uri {
   def toAbsoluteUrl: AbsoluteUrl =
     this match {
       case a: AbsoluteUrl => a
-      case _              => throw new UriConversionException(getClass.getSimpleName + " cannot be converted to AbsoluteUrl")
+      case _ => throw new UriConversionException(getClass.getSimpleName + " cannot be converted to AbsoluteUrl")
     }
 
   def toRelativeUrl: RelativeUrl =
@@ -468,7 +468,7 @@ sealed trait Url extends Uri {
     this match {
       case p: ProtocolRelativeUrl => p
       case a: AbsoluteUrl         => ProtocolRelativeUrl(a.authority, a.path, a.query, a.fragment)
-      case _                      => throw new UriConversionException(getClass.getSimpleName + " cannot be converted to ProtocolRelativeUrl")
+      case _ => throw new UriConversionException(getClass.getSimpleName + " cannot be converted to ProtocolRelativeUrl")
     }
 
   def toUrl: Url = this

--- a/shared/src/main/scala/io/lemonlabs/uri/typesafe/PathPart.scala
+++ b/shared/src/main/scala/io/lemonlabs/uri/typesafe/PathPart.scala
@@ -7,9 +7,6 @@ import simulacrum.typeclass
 
 import scala.language.implicitConversions
 import scala.annotation.implicitNotFound
-import scala.compiletime.package$package.{erasedValue, summonInline}
-import scala.deriving.Mirror
-import scala.deriving.*
 
 @implicitNotFound("Could not find an instance of PathPart for ${A}")
 @typeclass trait PathPart[-A] extends Serializable {
@@ -107,24 +104,7 @@ sealed trait TraversablePathPartsInstances {
     toSeq(a).toVector
 }
 
-object TraversablePathParts extends TraversablePathPartsInstances {
-  inline def product[A](implicit m: Mirror.ProductOf[A]): TraversablePathParts[A] = {
-    val elemInstances = summonAll[m.MirroredElemTypes]
-
-    new TraversablePathParts[A] {
-      override def toSeq(a: A): Seq[String] =
-        a.asInstanceOf[Product].productIterator.zip(elemInstances)
-          .flatMap { case (field, tc) => tc.asInstanceOf[TraversablePathParts[Any]].toSeq(field) }
-          .toSeq
-    }
-  }
-
-  inline private def summonAll[T <: Tuple]: List[TraversablePathParts[_]] =
-    inline erasedValue[T] match {
-      case _: EmptyTuple => Nil
-      case _: (t *: ts)  => summonInline[TraversablePathParts[t]] :: summonAll[ts]
-    }
-
+object TraversablePathParts extends TraversablePathPartsInstances with TraversablePathPartsDeriving {
   /* ======================================================================== */
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
   /* ======================================================================== */

--- a/shared/src/main/scala/io/lemonlabs/uri/typesafe/PathPart.scala
+++ b/shared/src/main/scala/io/lemonlabs/uri/typesafe/PathPart.scala
@@ -2,7 +2,7 @@ package io.lemonlabs.uri.typesafe
 
 import java.util.UUID
 import cats.Contravariant
-import cats.syntax.contravariant.*
+import cats.syntax.contravariant._
 import simulacrum.typeclass
 
 import scala.language.implicitConversions

--- a/shared/src/main/scala/io/lemonlabs/uri/typesafe/QueryKeyValue.scala
+++ b/shared/src/main/scala/io/lemonlabs/uri/typesafe/QueryKeyValue.scala
@@ -1,7 +1,7 @@
 package io.lemonlabs.uri.typesafe
 
 import cats.Contravariant
-import cats.syntax.contravariant.*
+import cats.syntax.contravariant._
 import simulacrum.typeclass
 
 import scala.language.implicitConversions

--- a/shared/src/test/scala/io/lemonlabs/uri/TypeClassTests.scala
+++ b/shared/src/test/scala/io/lemonlabs/uri/TypeClassTests.scala
@@ -61,9 +61,7 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
 
   "Foo" should "render correctly as path part" in {
     final case class Foo(a: String, b: Int)
-    object Foo {
-      given pathPart: TraversablePathParts[Foo] = TraversablePathParts.product
-    }
+    implicit val pathPart: TraversablePathParts[Foo] = TraversablePathParts.product
 
     val uri = Url.parse("http://example.com") addPathParts Foo(a = "user", b = 1)
     uri.toString should equal("http://example.com/user/1")
@@ -71,9 +69,7 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
 
   "Foo" should "render correctly as fragment" in {
     final case class Foo(a: String, b: Int)
-    object Foo {
-      given pathPart: Fragment[Foo] = (foo: Foo) => Some(s"${foo.a}-${foo.b}")
-    }
+    implicit val pathPart: Fragment[Foo] = (foo: Foo) => Some(s"${foo.a}-${foo.b}")
 
     val uri = Url.parse("/uris-in-scala.html") withFragment Foo(a = "user", b = 1)
     uri.toString should equal("/uris-in-scala.html#user-1")
@@ -81,9 +77,7 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
 
   "Foo" should "render correctly as query parameters" in {
     final case class Foo(a: String)
-    object Foo {
-      given fooQueryKeyValue: QueryKeyValue[Foo] = QueryKeyValue(_ => "foo", foo => Option(foo.a))
-    }
+    implicit val fooQueryKeyValue: QueryKeyValue[Foo] = QueryKeyValue(_ => "foo", foo => Option(foo.a))
 
     val uri = Url.parse("/uris-in-scala.html") addParam Foo("foo_value")
     uri.toString should equal("/uris-in-scala.html?foo=foo_value")
@@ -91,10 +85,7 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
 
   "addPathParts(TraversablePathParts)" should "derive type class for case class correctly" in {
     final case class Foo(a: Int, b: String)
-
-    object Foo {
-      given traversablePathParts: TraversablePathParts[Foo] = TraversablePathParts.product
-    }
+    implicit val traversablePathParts: TraversablePathParts[Foo] = TraversablePathParts.product
 
     val uri = Url.parse("/uris-in-scala") addPathParts Foo(a = 1, b = "bar")
     uri.toString should equal("/uris-in-scala/1/bar")
@@ -102,16 +93,10 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
 
   "addPathParts(TraversablePathParts)" should "derive type class for case classes structure correctly" in {
     final case class Foo(a: Int, b: String)
-
-    object Foo {
-      given traversablePathParts: TraversablePathParts[Foo] = TraversablePathParts.product
-    }
+    implicit val traversablePathPartsFoo: TraversablePathParts[Foo] = TraversablePathParts.product
 
     final case class Bar(c: Int, foo: Foo)
-
-    object Bar {
-      given traversablePathParts: TraversablePathParts[Bar] = TraversablePathParts.product
-    }
+    implicit val traversablePathPartsBar: TraversablePathParts[Bar] = TraversablePathParts.product
 
     val uri = Url.parse("/uris-in-scala") addPathParts Bar(c = 2, foo = Foo(a = 1, b = "bar"))
     uri.toString should equal("/uris-in-scala/2/1/bar")
@@ -119,10 +104,7 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
 
   "addPathParts(TraversablePathParts)" should "derive type class for case class with optional field correctly" in {
     final case class Foo(a: Int, b: Option[String])
-
-    object Foo {
-      given traversablePathParts: TraversablePathParts[Foo] = TraversablePathParts.product
-    }
+    implicit val traversablePathParts: TraversablePathParts[Foo] = TraversablePathParts.product
 
     val uriWithB = Url.parse("/uris-in-scala") addPathParts Foo(a = 1, b = Some("bar"))
     val uriWithoutB = Url.parse("/uris-in-scala") addPathParts Foo(a = 1, b = None)
@@ -132,10 +114,7 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
 
   "withPathParts(TraversablePathParts)" should "derive type class for case class correctly" in {
     final case class Foo(a: Int, b: String)
-
-    object Foo {
-      given traversablePathParts: TraversablePathParts[Foo] = TraversablePathParts.product
-    }
+    implicit val traversablePathParts: TraversablePathParts[Foo] = TraversablePathParts.product
 
     val uri = Url.parse("/uris-in-scala") withPathParts Foo(a = 1, b = "bar")
     uri.toString should equal("/1/bar")
@@ -143,16 +122,10 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
 
   "withPathParts(TraversablePathParts)" should "derive type class for case classes structure correctly" in {
     final case class Foo(a: Int, b: String)
-
-    object Foo {
-      given traversablePathParts: TraversablePathParts[Foo] = TraversablePathParts.product
-    }
+    implicit val traversablePathPartsFoo: TraversablePathParts[Foo] = TraversablePathParts.product
 
     final case class Bar(c: Int, foo: Foo)
-
-    object Bar {
-      given traversablePathParts: TraversablePathParts[Bar] = TraversablePathParts.product
-    }
+    implicit val traversablePathPartsBar: TraversablePathParts[Bar] = TraversablePathParts.product
 
     val uri = Url.parse("/uris-in-scala") withPathParts Bar(c = 2, foo = Foo(a = 1, b = "bar"))
     uri.toString should equal("/2/1/bar")
@@ -160,10 +133,7 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
 
   "withPathParts(TraversablePathParts)" should "derive type class for case class with optional field correctly" in {
     final case class Foo(a: Int, b: Option[String])
-
-    object Foo {
-      given traversablePathParts: TraversablePathParts[Foo] = TraversablePathParts.product
-    }
+    implicit val traversablePathPartsFoo: TraversablePathParts[Foo] = TraversablePathParts.product
 
     val uriWithB = Url.parse("/uris-in-scala") withPathParts Foo(a = 1, b = Some("bar"))
     val uriWithoutB = Url.parse("/uris-in-scala") withPathParts Foo(a = 1, b = None)
@@ -198,10 +168,7 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
 
   "TraversableParams" should "derive type class for case class correctly" in {
     final case class Foo(a: Int, b: String)
-
-    object Foo {
-      given traversableParams: TraversableParams[Foo] = TraversableParams.product
-    }
+    implicit val traversableParamsFoo: TraversableParams[Foo] = TraversableParams.product
 
     val uri = Url.parse("/uris-in-scala.html") addParams Foo(a = 1, b = "bar")
     uri.toString should equal("/uris-in-scala.html?a=1&b=bar")
@@ -209,16 +176,10 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
 
   "TraversableParams" should "derive type class for case classes structure correctly" in {
     final case class Foo(a: Int, b: String)
-
-    object Foo {
-      given traversableParams: TraversableParams[Foo] = TraversableParams.product
-    }
+    implicit val traversableParamsFoo: TraversableParams[Foo] = TraversableParams.product
 
     final case class Bar(c: Int, foo: Foo)
-
-    object Bar {
-      given traversableParams: TraversableParams[Bar] = TraversableParams.product
-    }
+    implicit val traversableParamsBar: TraversableParams[Bar] = TraversableParams.product
 
     val uri = Url.parse("/uris-in-scala.html") addParams Bar(c = 2, foo = Foo(a = 1, b = "bar"))
     uri.toString should equal("/uris-in-scala.html?c=2&a=1&b=bar")
@@ -226,10 +187,7 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
 
   "TraversableParams" should "derive type class for case class with optional field correctly" in {
     final case class Foo(a: Int, b: Option[String])
-
-    object Foo {
-      given traversableParams: TraversableParams[Foo] = TraversableParams.product
-    }
+    implicit val traversableParamsFoo: TraversableParams[Foo] = TraversableParams.product
 
     val uriWithB = Url.parse("/uris-in-scala.html") addParams Foo(a = 1, b = Some("bar"))
     val uriWithoutB = Url.parse("/uris-in-scala.html") addParams Foo(a = 1, b = None)
@@ -237,7 +195,7 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
     uriWithoutB.toString should equal("/uris-in-scala.html?a=1&b")
 
     {
-      given config: UriConfig = UriConfig(renderQuery = ExcludeNones)
+      implicit val config: UriConfig = UriConfig(renderQuery = ExcludeNones)
       val uriWithBexludingNones = Url.parse("/uris-in-scala.html") addParams Foo(a = 1, b = Some("bar"))
       val uriWithoutBexludingNones = Url.parse("/uris-in-scala.html") addParams Foo(a = 1, b = None)
       uriWithBexludingNones.toString should equal("/uris-in-scala.html?a=1&b=bar")
@@ -258,9 +216,7 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
       val name: String = "B"
     }
 
-    object Foo {
-      given queryValue: QueryValue[Foo] = QueryValue.derive[Foo].by(_.name)
-    }
+    implicit val queryValue: QueryValue[Foo] = QueryValue.derive[Foo].by(_.name)
 
     val uriA = Url.parse("/uris-in-scala.html") addParam ("foo" -> A)
     val uriB = Url.parse("/uris-in-scala.html") addParam ("foo" -> B)

--- a/shared/src/test/scala/io/lemonlabs/uri/TypesafeDslTypeTests.scala
+++ b/shared/src/test/scala/io/lemonlabs/uri/TypesafeDslTypeTests.scala
@@ -35,10 +35,7 @@ class TypesafeDslTypeTests extends AnyFlatSpec with Matchers {
 
   "Foo" should "render correctly as path part" in {
     final case class Foo(a: String, b: Int)
-    object Foo {
-      given pathPart: TraversablePathParts[Foo] =
-        TraversablePathParts.product
-    }
+    implicit val pathPart: TraversablePathParts[Foo] = TraversablePathParts.product
 
     val uri = "http://example.com" / Foo(a = "user", b = 1)
     uri.toString should equal("http://example.com/user/1")
@@ -56,9 +53,7 @@ class TypesafeDslTypeTests extends AnyFlatSpec with Matchers {
 
   "Foo" should "render correctly as query parameters" in {
     final case class Foo(a: String)
-    object Foo {
-      implicit val fooQueryKeyValue: QueryKeyValue[Foo] = QueryKeyValue(_ => "foo", foo => Option(foo.a))
-    }
+    implicit val fooQueryKeyValue: QueryKeyValue[Foo] = QueryKeyValue(_ => "foo", foo => Option(foo.a))
 
     val uri = "/uris-in-scala.html" ? Foo("foo_value")
     uri.toString should equal("/uris-in-scala.html?foo=foo_value")
@@ -66,10 +61,7 @@ class TypesafeDslTypeTests extends AnyFlatSpec with Matchers {
 
   "TraversableParams" should "derive type class for case class correctly" in {
     final case class Foo(a: Int, b: String)
-
-    object Foo {
-      given traversableParams: TraversableParams[Foo] = TraversableParams.product
-    }
+    implicit val traversableParams: TraversableParams[Foo] = TraversableParams.product
 
     val uri = "/uris-in-scala.html" addParams Foo(a = 1, b = "bar")
     uri.toString should equal("/uris-in-scala.html?a=1&b=bar")
@@ -77,16 +69,10 @@ class TypesafeDslTypeTests extends AnyFlatSpec with Matchers {
 
   "TraversableParams" should "derive type class for case classes structure correctly" in {
     final case class Foo(a: Int, b: String)
-
-    object Foo {
-      given traversableParams: TraversableParams[Foo] = TraversableParams.product
-    }
+    implicit val traversableParamsFoo: TraversableParams[Foo] = TraversableParams.product
 
     final case class Bar(c: Int, foo: Foo)
-
-    object Bar {
-      given traversableParams: TraversableParams[Bar] = TraversableParams.product
-    }
+    implicit val traversableParamsBar: TraversableParams[Bar] = TraversableParams.product
 
     val uri = "/uris-in-scala.html" addParams Bar(c = 2, foo = Foo(a = 1, b = "bar"))
     uri.toString should equal("/uris-in-scala.html?c=2&a=1&b=bar")
@@ -94,10 +80,7 @@ class TypesafeDslTypeTests extends AnyFlatSpec with Matchers {
 
   "TraversableParams" should "derive type class for case class with optional field correctly" in {
     final case class Foo(a: Int, b: Option[String])
-
-    object Foo {
-      given traversableParams: TraversableParams[Foo] = TraversableParams.product
-    }
+    implicit val traversableParamsFoo: TraversableParams[Foo] = TraversableParams.product
 
     val uriWithB = "/uris-in-scala.html" addParams Foo(a = 1, b = Some("bar"))
     val uriWithoutB = "/uris-in-scala.html" addParams Foo(a = 1, b = None)
@@ -126,9 +109,7 @@ class TypesafeDslTypeTests extends AnyFlatSpec with Matchers {
       val name: String = "B"
     }
 
-    object Foo {
-      implicit val queryValue: QueryValue[Foo] = QueryValue.derive[Foo].by(_.name)
-    }
+    implicit val queryValue: QueryValue[Foo] = QueryValue.derive[Foo].by(_.name)
 
     val uriA = "/uris-in-scala.html" ? ("foo" -> A)
     val uriB = "/uris-in-scala.html" ? ("foo" -> B)


### PR DESCRIPTION
@theon I've implemented scala version specific source directories as suggested in your [comment](https://github.com/lemonlabsuk/scala-uri/pull/343#issuecomment-918520935).

Regarding scala.js: as far as I know, scala.js won't support scala 3 any time soon. [Source](https://www.scala-lang.org/2020/11/03/scalajs-for-scala-3.html)