### PR TITLE
Scala 3 Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
         env:
           SCALA_VERSION: ${{ matrix.scala }}
           PROJECT: ${{ matrix.project }}
+          SBT_OPTS: -Xss10m
         run: >
           sbt ++$SCALA_VERSION check mdoc coverage $PROJECT/test coverageReport &&
           cd target &&

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,14 @@ jobs:
 
     strategy:
       matrix:
-        scala: [2.12.14, 2.13.6]
+        scala: [2.12.14, 2.13.6, 3.0.1]
         project: [scalaUriJVM, scalaUriJS]
+        exclude:
+          # Unable to run the tests for Scala.js + Scala3. Same issue as described here:
+          # https://github.com/softwaremill/quicklens/issues/67
+          # TODO: Re-enable once resolved
+          - scala: 3.0.1
+            project: scalaUriJS
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,22 @@ jobs:
 
     strategy:
       matrix:
-        scala: [2.12.14, 2.13.6, 3.0.1]
+        scala: [2.12.14, 2.13.6]
         project: [scalaUriJVM, scalaUriJS]
+        coverage: [coverage]
+        coverageReport: [coverageReport]
         exclude:
           # Unable to run the tests for Scala.js + Scala3. Same issue as described here:
           # https://github.com/softwaremill/quicklens/issues/67
           # TODO: Re-enable once resolved
           - scala: 3.0.1
             project: scalaUriJS
+        include:
+          # https://github.com/scoverage/scalac-scoverage-plugin/issues/299
+          - scala: 3.0.1
+            project: scalaUriJVM
+            coverage: ""
+            coverageReport: ""
 
     steps:
       - name: Checkout Code
@@ -52,9 +60,11 @@ jobs:
         env:
           SCALA_VERSION: ${{ matrix.scala }}
           PROJECT: ${{ matrix.project }}
+          COVERAGE: ${{ matrix.coverage }}
+          COVERAGE_REPORT: ${{ matrix.coverageReport }}
           SBT_OPTS: -Xss10m
         run: >
-          sbt ++$SCALA_VERSION check mdoc coverage $PROJECT/test coverageReport &&
+          sbt ++$SCALA_VERSION check mdoc $COVERAGE $PROJECT/test $COVERAGE_REPORT &&
           cd target &&
           git clone https://github.com/lemonlabsuk/scala-uri-demo.git &&
           cd scala-uri-demo &&

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
           cd target &&
           git clone https://github.com/lemonlabsuk/scala-uri-demo.git &&
           cd scala-uri-demo &&
-          sbt -Dscala.ver=$SCALA_VERSION -Dscala.uri.ver=3.5.0 test &&
+          sbt -Dscala.ver=$SCALA_VERSION -Dscala.uri.ver=4.0.0-M2 test &&
           cd "$TRAVIS_BUILD_DIR"
 
       - name: Report to CodeCov

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,5 @@
-version = 2.7.5
+version = 3.0.3
+runner.dialect = Scala3
 
 align.tokens              = [
   {code = "=>",  owner = "Case"},
@@ -11,7 +12,8 @@ project.excludeFilters = [
   "shared/src/main/scala/io/lemonlabs/uri/inet/PublicSuffixTrie.scala"
 ]
 align.openParenDefnSite    = true
-docstrings                 = ScalaDoc
+docstrings.style           = SpaceAsterisk
+docstrings.wrap            = no
 maxColumn                  = 120
 rewrite.rules              = [RedundantParens, SortImports]
 newlines.afterCurlyLambda  = preserve

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 To include it in your SBT project from maven central:
 
 ```scala
-"io.lemonlabs" %% "scala-uri" % "3.5.0"
+"io.lemonlabs" %% "scala-uri" % "4.0.0-M2"
 ```
 
 ## Migration Guides
@@ -898,13 +898,13 @@ The type class instances exist in the companion objects for these types.
  * For `2.11.x` support use `scala-uri` `1.4.10` from branch [`1.4.x`](https://github.com/lemonlabsuk/scala-uri/tree/1.4.x)
  * For `2.10.x` support use `scala-uri` `0.4.17` from branch [`0.4.x`](https://github.com/lemonlabsuk/scala-uri/tree/0.4.x)
  * For `2.9.x` support use `scala-uri` `0.3.6` from branch [`0.3.x`](https://github.com/lemonlabsuk/scala-uri/tree/0.3.x)
- * For Scala.js `1.x.x` support, use `scala-uri` `3.5.0`
+ * For Scala.js `1.x.x` support, use `scala-uri` `4.0.0-M2`
  * For Scala.js `0.6.x` support, use `scala-uri` `2.2.3`
 
 Release builds are available in maven central. For SBT users just add the following dependency:
 
 ```scala
-"io.lemonlabs" %% "scala-uri" % "3.5.0"
+"io.lemonlabs" %% "scala-uri" % "4.0.0-M2"
 ```
 
 For maven users you should use (for 2.13.x):
@@ -913,7 +913,7 @@ For maven users you should use (for 2.13.x):
 <dependency>
     <groupId>io.lemonlabs</groupId>
     <artifactId>scala-uri_2.13</artifactId>
-    <version>3.5.0</version>
+    <version>4.0.0-M2</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,11 @@
  * No dependencies on existing web frameworks
 
 To include it in your SBT project from maven central:
+```scala
+"io.lemonlabs" %% "scala-uri" % "3.5.0"
+```
 
+For Scala 3, there is an early build available:
 ```scala
 "io.lemonlabs" %% "scala-uri" % "4.0.0-M2"
 ```
@@ -893,6 +897,7 @@ The type class instances exist in the companion objects for these types.
 
 ## Including scala-uri your project
 
+`scala-uri` `4.x.x` is currently built with support for Scala `3`, Scala `2.13.x`, Scala `2.12.x` and Scala.js `1.1.0+`
 `scala-uri` `3.x.x` is currently built with support for Scala `2.13.x`, Scala `2.12.x` and Scala.js `1.1.0+` 
 
  * For `2.11.x` support use `scala-uri` `1.4.10` from branch [`1.4.x`](https://github.com/lemonlabsuk/scala-uri/tree/1.4.x)

--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ Only percent encode the hash character:
 import io.lemonlabs.uri.config.UriConfig
 import io.lemonlabs.uri.encoding._
 
-implicit val config = UriConfig(encoder = percentEncode('#'))
+implicit val config: UriConfig = UriConfig(encoder = percentEncode('#'))
 ```
 
 Percent encode all the default chars, except the plus character:
@@ -404,7 +404,7 @@ Percent encode all the default chars, except the plus character:
 import io.lemonlabs.uri.config.UriConfig
 import io.lemonlabs.uri.encoding._
 
-implicit val config = UriConfig(encoder = percentEncode -- '+')
+implicit val config: UriConfig = UriConfig(encoder = percentEncode -- '+')
 ```
 
 Encode all the default chars, and also encode the letters a and b:
@@ -413,7 +413,7 @@ Encode all the default chars, and also encode the letters a and b:
 import io.lemonlabs.uri.config.UriConfig
 import io.lemonlabs.uri.encoding._
 
-implicit val config = UriConfig(encoder = percentEncode ++ ('a', 'b'))
+implicit val config: UriConfig = UriConfig(encoder = percentEncode ++ ('a', 'b'))
 ```
 
 ### Encoding spaces as pluses
@@ -428,7 +428,7 @@ import io.lemonlabs.uri.config.UriConfig
 import io.lemonlabs.uri.encoding._
 import io.lemonlabs.uri.encoding.PercentEncoder._
 
-implicit val config = UriConfig.default.copy(queryEncoder = PercentEncoder())
+implicit val config: UriConfig = UriConfig.default.copy(queryEncoder = PercentEncoder())
 
 val uri = Url.parse("http://theon.github.com?test=uri with space")
 uri.toString // This is http://theon.github.com?test=uri%20with%20space
@@ -443,7 +443,7 @@ import io.lemonlabs.uri.Url
 import io.lemonlabs.uri.config.UriConfig
 import io.lemonlabs.uri.decoding._
 
-implicit val config = UriConfig.default.copy(queryDecoder = PercentDecoder)
+implicit val config: UriConfig = UriConfig.default.copy(queryDecoder = PercentDecoder)
 
 val uri = Url.parse("http://theon.github.com?test=uri+with+plus")
 uri.query.param("test") // This is Some("uri+with+plus")
@@ -458,7 +458,7 @@ import io.lemonlabs.uri.Url
 import io.lemonlabs.uri.config.UriConfig
 import io.lemonlabs.uri.encoding._
 
-implicit val config = UriConfig(encoder = percentEncode + encodeCharAs(' ', "_"))
+implicit val config: UriConfig = UriConfig(encoder = percentEncode + encodeCharAs(' ', "_"))
 
 val uri = Url.parse("http://theon.github.com/uri with space")
 uri.toString // This is http://theon.github.com/uri_with_space
@@ -484,7 +484,7 @@ import io.lemonlabs.uri.Url
 import io.lemonlabs.uri.config.UriConfig
 import io.lemonlabs.uri.decoding.NoopDecoder
 
-implicit val c = UriConfig(decoder = NoopDecoder)
+implicit val c: UriConfig = UriConfig(decoder = NoopDecoder)
 
 val uri = Url.parse("http://example.com/i-havent-%been%-percent-encoded")
 
@@ -507,7 +507,7 @@ import io.lemonlabs.uri.Url
 import io.lemonlabs.uri.config.UriConfig
 import io.lemonlabs.uri.decoding.PercentDecoder
 
-implicit val c = UriConfig(
+implicit val c: UriConfig = UriConfig(
   decoder = PercentDecoder(ignoreInvalidPercentEncoding = true)
 )
 val uri = Url.parse("/?x=%3")
@@ -638,7 +638,7 @@ This can be changed like so:
 import io.lemonlabs.uri.config.UriConfig
 import io.lemonlabs.uri.Url
 
-implicit val conf = UriConfig(charset = "GB2312")
+implicit val conf: UriConfig = UriConfig(charset = "GB2312")
 
 val uri = Url.parse("http://theon.github.com/uris-in-scala.html?chinese=网址")
 uri.toString // This is http://theon.github.com/uris-in-scala.html?chinese=%CD%F8%D6%B7

--- a/build.sbt
+++ b/build.sbt
@@ -20,6 +20,10 @@ publish / skip                 := true // Do not publish the root project
 val simulacrumScalafixVersion = "0.5.4"
 ThisBuild / scalafixDependencies += "org.typelevel" %% "simulacrum-scalafix" % simulacrumScalafixVersion
 
+val isScala3 = Def.setting {
+  CrossVersion.partialVersion(scalaVersion.value).exists(_._1 != 2)
+}
+
 val sharedSettings = Seq(
   organization := "io.lemonlabs",
   libraryDependencies ++= Seq(
@@ -67,6 +71,7 @@ val scalaUriSettings = Seq(
     "org.typelevel" %%% "cats-core"  % "2.6.1",
     "org.typelevel" %%% "cats-parse" % "0.3.4"
   ),
+  libraryDependencies ++= (if (isScala3.value) Nil else Seq("com.chuusai" %%% "shapeless" % "2.3.7")),
   pomPostProcess := { node =>
     new RuleTransformer(new RewriteRule {
       override def transform(node: xml.Node): Seq[xml.Node] = {

--- a/build.sbt
+++ b/build.sbt
@@ -48,9 +48,7 @@ val sharedSettings = Seq(
       case _                                                => Nil
     }
   ),
-  semanticdbEnabled := true,
-//  addCompilerPlugin(scalafixSemanticdb),
-//  scalacOptions ++= Seq(s"-P:semanticdb:targetroot:${baseDirectory.value}/target/.semanticdb", "-Yrangepos"),
+  semanticdbEnabled        := true,
   Test / parallelExecution := false,
   scalafmtOnCompile        := true,
   coverageExcludedPackages := "(io.lemonlabs.uri.inet.Trie.*|io.lemonlabs.uri.inet.PublicSuffixes.*|io.lemonlabs.uri.inet.PublicSuffixTrie.*|io.lemonlabs.uri.inet.PunycodeSupport.*)"

--- a/build.sbt
+++ b/build.sbt
@@ -48,7 +48,7 @@ val sharedSettings = Seq(
 //  addCompilerPlugin(scalafixSemanticdb),
 //  scalacOptions ++= Seq(s"-P:semanticdb:targetroot:${baseDirectory.value}/target/.semanticdb", "-Yrangepos"),
   Test / parallelExecution := false,
-  scalafmtOnCompile        := true,
+//  scalafmtOnCompile        := true,
   coverageExcludedPackages := "(io.lemonlabs.uri.inet.Trie.*|io.lemonlabs.uri.inet.PublicSuffixes.*|io.lemonlabs.uri.inet.PublicSuffixTrie.*|io.lemonlabs.uri.inet.PunycodeSupport.*)"
 )
 
@@ -64,8 +64,6 @@ val scalaUriSettings = Seq(
   name        := "scala-uri",
   description := "Simple scala library for building and parsing URIs",
   libraryDependencies ++= Seq(
-    // TODO: Remove for3Use2_13 when scala3 version available https://github.com/milessabin/shapeless/issues/1043
-    ("com.chuusai"   %%% "shapeless"  % "2.3.7").cross(CrossVersion.for3Use2_13),
     "org.typelevel" %%% "cats-core"  % "2.6.1",
     "org.typelevel" %%% "cats-parse" % "0.3.4"
   ),

--- a/build.sbt
+++ b/build.sbt
@@ -13,8 +13,8 @@ import com.typesafe.tools.mima.plugin.MimaKeys.{mimaBinaryIssueFilters, mimaPrev
 
 name := "scala-uri root"
 
-ThisBuild / scalaVersion       := "2.13.6"
-ThisBuild / crossScalaVersions := Seq("2.12.14", scalaVersion.value)
+ThisBuild / scalaVersion       := "3.0.1"
+ThisBuild / crossScalaVersions := Seq("2.12.14", "2.13.6", scalaVersion.value)
 publish / skip                 := true // Do not publish the root project
 
 val simulacrumScalafixVersion = "0.5.4"
@@ -25,7 +25,7 @@ val sharedSettings = Seq(
   libraryDependencies ++= Seq(
     "org.typelevel"     %%% "simulacrum-scalafix-annotations" % simulacrumScalafixVersion,
     "org.scalatest"     %%% "scalatest"                       % "3.2.9"   % Test,
-    "org.scalatestplus" %%% "scalacheck-1-14"                 % "3.2.2.0" % Test,
+    "org.scalatestplus" %%% "scalacheck-1-15"                 % "3.2.9.0" % Test,
     "org.scalacheck"    %%% "scalacheck"                      % "1.15.4"  % Test,
     "org.typelevel"     %%% "cats-laws"                       % "2.6.1"   % Test
   ),
@@ -36,16 +36,17 @@ val sharedSettings = Seq(
     "utf8",
     "-feature",
     "-Xfatal-warnings",
-    "-language:higherKinds"
+    "-language:higherKinds,implicitConversions"
   ) ++ (
     VersionNumber(scalaVersion.value) match {
-      case v if v.matchesSemVer(SemanticSelector(">=2.13")) => Seq("-Ymacro-annotations")
+      case v if v.matchesSemVer(SemanticSelector("=2.13")) => Seq("-Ymacro-annotations")
       case v if v.matchesSemVer(SemanticSelector("<=2.12")) => Seq("-Ypartial-unification")
       case _                                                => Nil
     }
   ),
-  addCompilerPlugin(scalafixSemanticdb),
-  scalacOptions ++= Seq(s"-P:semanticdb:targetroot:${baseDirectory.value}/target/.semanticdb", "-Yrangepos"),
+  semanticdbEnabled := true,
+//  addCompilerPlugin(scalafixSemanticdb),
+//  scalacOptions ++= Seq(s"-P:semanticdb:targetroot:${baseDirectory.value}/target/.semanticdb", "-Yrangepos"),
   Test / parallelExecution := false,
   scalafmtOnCompile        := true,
   coverageExcludedPackages := "(io.lemonlabs.uri.inet.Trie.*|io.lemonlabs.uri.inet.PublicSuffixes.*|io.lemonlabs.uri.inet.PublicSuffixTrie.*|io.lemonlabs.uri.inet.PunycodeSupport.*)"
@@ -63,7 +64,8 @@ val scalaUriSettings = Seq(
   name        := "scala-uri",
   description := "Simple scala library for building and parsing URIs",
   libraryDependencies ++= Seq(
-    "com.chuusai"   %%% "shapeless"  % "2.3.7",
+    // TODO: Remove for3Use2_13 when scala3 version available https://github.com/milessabin/shapeless/issues/1043
+    ("com.chuusai"   %%% "shapeless"  % "2.3.7").cross(CrossVersion.for3Use2_13),
     "org.typelevel" %%% "cats-core"  % "2.6.1",
     "org.typelevel" %%% "cats-parse" % "0.3.4"
   ),
@@ -162,7 +164,8 @@ lazy val scalaUri =
       Test / fork := true
     )
     .jsSettings(
-      libraryDependencies += "org.scala-js" %%% "scalajs-dom" % "1.2.0"
+      // TODO: Remove for3Use2_13 when scala3 version available https://github.com/scala-js/scala-js-dom/issues/451
+      libraryDependencies += ("org.scala-js" %%% "scalajs-dom" % "1.2.0").cross(CrossVersion.for3Use2_13)
     )
 
 lazy val docs = project

--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ val sharedSettings = Seq(
     "-language:higherKinds,implicitConversions"
   ) ++ (
     VersionNumber(scalaVersion.value) match {
-      case v if v.matchesSemVer(SemanticSelector("=2.13")) => Seq("-Ymacro-annotations")
+      case v if v.matchesSemVer(SemanticSelector("=2.13"))  => Seq("-Ymacro-annotations")
       case v if v.matchesSemVer(SemanticSelector("<=2.12")) => Seq("-Ypartial-unification")
       case _                                                => Nil
     }
@@ -52,7 +52,7 @@ val sharedSettings = Seq(
 //  addCompilerPlugin(scalafixSemanticdb),
 //  scalacOptions ++= Seq(s"-P:semanticdb:targetroot:${baseDirectory.value}/target/.semanticdb", "-Yrangepos"),
   Test / parallelExecution := false,
-//  scalafmtOnCompile        := true,
+  scalafmtOnCompile        := true,
   coverageExcludedPackages := "(io.lemonlabs.uri.inet.Trie.*|io.lemonlabs.uri.inet.PublicSuffixes.*|io.lemonlabs.uri.inet.PublicSuffixTrie.*|io.lemonlabs.uri.inet.PunycodeSupport.*)"
 )
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "shared/src/main/scala-2/io/lemonlabs/uri/typesafe"

--- a/project/UpdatePublicSuffixes.scala
+++ b/project/UpdatePublicSuffixes.scala
@@ -45,15 +45,15 @@ object UpdatePublicSuffixes {
     p.println("")
     p.println("object PublicSuffixes {")
 
-    p.println("  lazy val exceptions = Set(")
+    p.println("  lazy val exceptions: Set[String] = Set(")
     p.println(exceptions.map(_.tail).map(e => s"""    "$e"""").mkString(",\n"))
     p.println("  )\n")
 
-    p.println("  lazy val wildcardPrefixes = Set(")
+    p.println("  lazy val wildcardPrefixes: Set[String] = Set(")
     p.println(wildcardPrefixes.map(_.drop(2)).map(w => s"""    "$w"""").mkString(",\n"))
     p.println("  )\n")
 
-    p.println("  lazy val set = " + groups.keys.map(i => s"publicSuffixes$i").mkString(" ++ "))
+    p.println("  lazy val set: Set[String] = " + groups.keys.map(i => s"publicSuffixes$i").mkString(" ++ "))
     groups.foreach { case (index, group) =>
       val setArgs = group.map(suffix => s"""      "$suffix"""").mkString(",\n")
       p.println(s"  private def publicSuffixes$index =\n    Set(\n" + setArgs + "\n    )")

--- a/shared/src/main/scala-2/io/lemonlabs/uri/typesafe/TraversableParamsDeriving.scala
+++ b/shared/src/main/scala-2/io/lemonlabs/uri/typesafe/TraversableParamsDeriving.scala
@@ -1,0 +1,30 @@
+package io.lemonlabs.uri.typesafe
+
+import cats.syntax.contravariant._
+import shapeless._
+import shapeless.labelled._
+import shapeless.ops.coproduct.Reify
+import shapeless.ops.hlist.ToList
+
+trait TraversableParamsDeriving {
+  implicit def field[K <: Symbol, V](implicit K: Witness.Aux[K], V: QueryValue[V]): TraversableParams[FieldType[K, V]] =
+    (a: FieldType[K, V]) => List(K.value.name -> V.queryValue(a))
+
+  implicit def sub[K <: Symbol, V](implicit
+                                   K: Witness.Aux[K],
+                                   V: TraversableParams[V]
+                                  ): TraversableParams[FieldType[K, V]] =
+    (a: FieldType[K, V]) => V.toSeq(a)
+
+  implicit val hnil: TraversableParams[HNil] =
+    (_: HNil) => List.empty
+
+  implicit def hcons[H, T <: HList](implicit
+                                    H: TraversableParams[H],
+                                    T: TraversableParams[T]
+                                   ): TraversableParams[H :: T] =
+    (a: H :: T) => H.toSeq(a.head) ++ T.toSeq(a.tail)
+
+  def product[A, R <: HList](implicit gen: LabelledGeneric.Aux[A, R], R: TraversableParams[R]): TraversableParams[A] =
+    (a: A) => R.toSeq(gen.to(a))
+}

--- a/shared/src/main/scala-2/io/lemonlabs/uri/typesafe/TraversableParamsDeriving.scala
+++ b/shared/src/main/scala-2/io/lemonlabs/uri/typesafe/TraversableParamsDeriving.scala
@@ -11,18 +11,18 @@ trait TraversableParamsDeriving {
     (a: FieldType[K, V]) => List(K.value.name -> V.queryValue(a))
 
   implicit def sub[K <: Symbol, V](implicit
-                                   K: Witness.Aux[K],
-                                   V: TraversableParams[V]
-                                  ): TraversableParams[FieldType[K, V]] =
+      K: Witness.Aux[K],
+      V: TraversableParams[V]
+  ): TraversableParams[FieldType[K, V]] =
     (a: FieldType[K, V]) => V.toSeq(a)
 
   implicit val hnil: TraversableParams[HNil] =
     (_: HNil) => List.empty
 
   implicit def hcons[H, T <: HList](implicit
-                                    H: TraversableParams[H],
-                                    T: TraversableParams[T]
-                                   ): TraversableParams[H :: T] =
+      H: TraversableParams[H],
+      T: TraversableParams[T]
+  ): TraversableParams[H :: T] =
     (a: H :: T) => H.toSeq(a.head) ++ T.toSeq(a.tail)
 
   def product[A, R <: HList](implicit gen: LabelledGeneric.Aux[A, R], R: TraversableParams[R]): TraversableParams[A] =

--- a/shared/src/main/scala-2/io/lemonlabs/uri/typesafe/TraversablePathPartsDeriving.scala
+++ b/shared/src/main/scala-2/io/lemonlabs/uri/typesafe/TraversablePathPartsDeriving.scala
@@ -6,24 +6,24 @@ import shapeless.labelled._
 
 trait TraversablePathPartsDeriving {
   implicit def field[K <: Symbol, V](implicit
-                                     K: Witness.Aux[K],
-                                     V: PathPart[V]
-                                    ): TraversablePathParts[FieldType[K, V]] =
+      K: Witness.Aux[K],
+      V: PathPart[V]
+  ): TraversablePathParts[FieldType[K, V]] =
     (a: FieldType[K, V]) => V.splitPath(a)
 
   implicit def sub[K <: Symbol, V](implicit
-                                   K: Witness.Aux[K],
-                                   V: TraversablePathParts[V]
-                                  ): TraversablePathParts[FieldType[K, V]] =
+      K: Witness.Aux[K],
+      V: TraversablePathParts[V]
+  ): TraversablePathParts[FieldType[K, V]] =
     (a: FieldType[K, V]) => V.toSeq(a)
 
   implicit val hnil: TraversablePathParts[HNil] =
     (_: HNil) => Seq.empty
 
   implicit def hcons[H, T <: HList](implicit
-                                    H: TraversablePathParts[H],
-                                    T: TraversablePathParts[T]
-                                   ): TraversablePathParts[H :: T] =
+      H: TraversablePathParts[H],
+      T: TraversablePathParts[T]
+  ): TraversablePathParts[H :: T] =
     (a: H :: T) => H.toSeq(a.head) ++ T.toSeq(a.tail)
 
   def product[A, R <: HList](implicit gen: Generic.Aux[A, R], R: TraversablePathParts[R]): TraversablePathParts[A] =

--- a/shared/src/main/scala-2/io/lemonlabs/uri/typesafe/TraversablePathPartsDeriving.scala
+++ b/shared/src/main/scala-2/io/lemonlabs/uri/typesafe/TraversablePathPartsDeriving.scala
@@ -1,0 +1,31 @@
+package io.lemonlabs.uri.typesafe
+
+import cats.syntax.contravariant._
+import shapeless._
+import shapeless.labelled._
+
+trait TraversablePathPartsDeriving {
+  implicit def field[K <: Symbol, V](implicit
+                                     K: Witness.Aux[K],
+                                     V: PathPart[V]
+                                    ): TraversablePathParts[FieldType[K, V]] =
+    (a: FieldType[K, V]) => V.splitPath(a)
+
+  implicit def sub[K <: Symbol, V](implicit
+                                   K: Witness.Aux[K],
+                                   V: TraversablePathParts[V]
+                                  ): TraversablePathParts[FieldType[K, V]] =
+    (a: FieldType[K, V]) => V.toSeq(a)
+
+  implicit val hnil: TraversablePathParts[HNil] =
+    (_: HNil) => Seq.empty
+
+  implicit def hcons[H, T <: HList](implicit
+                                    H: TraversablePathParts[H],
+                                    T: TraversablePathParts[T]
+                                   ): TraversablePathParts[H :: T] =
+    (a: H :: T) => H.toSeq(a.head) ++ T.toSeq(a.tail)
+
+  def product[A, R <: HList](implicit gen: Generic.Aux[A, R], R: TraversablePathParts[R]): TraversablePathParts[A] =
+    (a: A) => R.toSeq(gen.to(a))
+}

--- a/shared/src/main/scala-3/io/lemonlabs/uri/typesafe /TraversableParamsDeriving.scala
+++ b/shared/src/main/scala-3/io/lemonlabs/uri/typesafe /TraversableParamsDeriving.scala
@@ -1,0 +1,28 @@
+package io.lemonlabs.uri.typesafe
+
+import scala.compiletime.{erasedValue, summonInline}
+import scala.deriving.Mirror
+
+trait TraversableParamsDeriving {
+  inline def product[A](implicit m: Mirror.ProductOf[A]): TraversableParams[A] = {
+    val elemInstances = summonAll[m.MirroredElemTypes]
+
+    new TraversableParams[A] {
+      override def toSeq(a: A): Seq[(String, Option[String])] =
+        a.asInstanceOf[Product].productElementNames
+          .zip(a.asInstanceOf[Product].productIterator)
+          .zip(elemInstances)
+          .flatMap {
+            case ((name, field), tc : QueryValue[_]) => Seq((name, tc.asInstanceOf[QueryValue[Any]].queryValue(field)))
+            case ((name, field), tc : TraversableParams[_]) => tc.asInstanceOf[TraversableParams[Any]].toSeq(field)
+          }
+          .toSeq
+    }
+  }
+
+  inline def summonAll[T <: Tuple]: List[QueryValue[_] | TraversableParams[_]] =
+    inline erasedValue[T] match {
+      case _: EmptyTuple => Nil
+      case _: (t *: ts)  => summonInline[TraversableParams[t] | QueryValue[t]] :: summonAll[ts]
+    }
+}

--- a/shared/src/main/scala-3/io/lemonlabs/uri/typesafe /TraversableParamsDeriving.scala
+++ b/shared/src/main/scala-3/io/lemonlabs/uri/typesafe /TraversableParamsDeriving.scala
@@ -9,12 +9,13 @@ trait TraversableParamsDeriving {
 
     new TraversableParams[A] {
       override def toSeq(a: A): Seq[(String, Option[String])] =
-        a.asInstanceOf[Product].productElementNames
+        a.asInstanceOf[Product]
+          .productElementNames
           .zip(a.asInstanceOf[Product].productIterator)
           .zip(elemInstances)
           .flatMap {
-            case ((name, field), tc : QueryValue[_]) => Seq((name, tc.asInstanceOf[QueryValue[Any]].queryValue(field)))
-            case ((name, field), tc : TraversableParams[_]) => tc.asInstanceOf[TraversableParams[Any]].toSeq(field)
+            case ((name, field), tc: QueryValue[_]) => Seq((name, tc.asInstanceOf[QueryValue[Any]].queryValue(field)))
+            case ((name, field), tc: TraversableParams[_]) => tc.asInstanceOf[TraversableParams[Any]].toSeq(field)
           }
           .toSeq
     }

--- a/shared/src/main/scala-3/io/lemonlabs/uri/typesafe /TraversablePathPartsDeriving.scala
+++ b/shared/src/main/scala-3/io/lemonlabs/uri/typesafe /TraversablePathPartsDeriving.scala
@@ -9,7 +9,9 @@ trait TraversablePathPartsDeriving {
 
     new TraversablePathParts[A] {
       override def toSeq(a: A): Seq[String] =
-        a.asInstanceOf[Product].productIterator.zip(elemInstances)
+        a.asInstanceOf[Product]
+          .productIterator
+          .zip(elemInstances)
           .flatMap { case (field, tc) => tc.asInstanceOf[TraversablePathParts[Any]].toSeq(field) }
           .toSeq
     }

--- a/shared/src/main/scala-3/io/lemonlabs/uri/typesafe /TraversablePathPartsDeriving.scala
+++ b/shared/src/main/scala-3/io/lemonlabs/uri/typesafe /TraversablePathPartsDeriving.scala
@@ -1,0 +1,23 @@
+package io.lemonlabs.uri.typesafe
+
+import scala.compiletime.{erasedValue, summonInline}
+import scala.deriving.Mirror
+
+trait TraversablePathPartsDeriving {
+  inline def product[A](implicit m: Mirror.ProductOf[A]): TraversablePathParts[A] = {
+    val elemInstances = summonAll[m.MirroredElemTypes]
+
+    new TraversablePathParts[A] {
+      override def toSeq(a: A): Seq[String] =
+        a.asInstanceOf[Product].productIterator.zip(elemInstances)
+          .flatMap { case (field, tc) => tc.asInstanceOf[TraversablePathParts[Any]].toSeq(field) }
+          .toSeq
+    }
+  }
+
+  inline def summonAll[T <: Tuple]: List[TraversablePathParts[_]] =
+    inline erasedValue[T] match {
+      case _: EmptyTuple => Nil
+      case _: (t *: ts)  => summonInline[TraversablePathParts[t]] :: summonAll[ts]
+    }
+}

--- a/shared/src/main/scala/io/lemonlabs/uri/Authority.scala
+++ b/shared/src/main/scala/io/lemonlabs/uri/Authority.scala
@@ -77,10 +77,10 @@ case class Authority(userInfo: Option[UserInfo], host: Host, port: Option[Int])(
     toString(config, _.toStringPunycode)
 
   override def toString: String =
-    toString(config, _.toString)
+    toString(config, _.toString())
 
   def toStringRaw: String =
-    toString(config.withNoEncoding, _.toString)
+    toString(config.withNoEncoding, _.toString())
 
   /** Returns this authority normalized according to
     * <a href="http://www.ietf.org/rfc/rfc3986.txt">RFC 3986</a>

--- a/shared/src/main/scala/io/lemonlabs/uri/Path.scala
+++ b/shared/src/main/scala/io/lemonlabs/uri/Path.scala
@@ -15,7 +15,7 @@ import scala.util.Try
 sealed trait Path extends Product with Serializable {
   def config: UriConfig
   def parts: Vector[String]
-  private[uri] def toString(config: UriConfig): String
+  private[uri] def toStringWithConfig(config: UriConfig): String
 
   def isEmpty: Boolean
   def nonEmpty: Boolean = !isEmpty
@@ -24,10 +24,10 @@ sealed trait Path extends Product with Serializable {
     * @return String containing the raw path for this Uri
     */
   def toStringRaw: String =
-    toString(config.withNoEncoding)
+    toStringWithConfig(config.withNoEncoding)
 
   override def toString: String =
-    toString(config)
+    toStringWithConfig(config)
 }
 
 object Path {
@@ -94,7 +94,7 @@ sealed trait UrlPath extends Path {
   /** Returns the encoded path. By default non ASCII characters in the path are percent encoded.
     * @return String containing the path for this Uri
     */
-  private[uri] def toString(c: UriConfig): String = {
+  private[uri] def toStringWithConfig(c: UriConfig): String = {
     val encodedParts = parts.map(p => c.pathEncoder.encode(p, c.charset))
     encodedParts.mkString("/")
   }
@@ -233,7 +233,7 @@ case object EmptyPath extends AbsoluteOrEmptyPath {
   def unapply(path: UrlPath): Boolean =
     path.isEmpty
 
-  override private[uri] def toString(c: UriConfig): String = ""
+  override private[uri] def toStringWithConfig(c: UriConfig): String = ""
 
   override def isSlashTerminated: Boolean = false
 }
@@ -287,8 +287,8 @@ final case class AbsolutePath(parts: Vector[String])(implicit val config: UriCon
   def isEmpty: Boolean =
     false
 
-  override private[uri] def toString(c: UriConfig): String =
-    "/" + super.toString(c)
+  override private[uri] def toStringWithConfig(c: UriConfig): String =
+    "/" + super.toStringWithConfig(c)
 
   override def isSlashTerminated: Boolean =
     parts.lastOption.fold(true)(_ == "")
@@ -314,7 +314,7 @@ final case class UrnPath(nid: String, nss: String)(implicit val config: UriConfi
   def isEmpty: Boolean =
     false
 
-  private[uri] def toString(c: UriConfig): String =
+  private[uri] def toStringWithConfig(c: UriConfig): String =
     nid + ":" + c.pathEncoder.encode(nss, c.charset)
 }
 

--- a/shared/src/main/scala/io/lemonlabs/uri/Uri.scala
+++ b/shared/src/main/scala/io/lemonlabs/uri/Uri.scala
@@ -455,7 +455,7 @@ sealed trait Url extends Uri {
   def toAbsoluteUrl: AbsoluteUrl =
     this match {
       case a: AbsoluteUrl => a
-      case _              => throw new UriConversionException(getClass.getSimpleName + " cannot be converted to AbsoluteUrl")
+      case _ => throw new UriConversionException(getClass.getSimpleName + " cannot be converted to AbsoluteUrl")
     }
 
   def toRelativeUrl: RelativeUrl =
@@ -468,7 +468,7 @@ sealed trait Url extends Uri {
     this match {
       case p: ProtocolRelativeUrl => p
       case a: AbsoluteUrl         => ProtocolRelativeUrl(a.authority, a.path, a.query, a.fragment)
-      case _                      => throw new UriConversionException(getClass.getSimpleName + " cannot be converted to ProtocolRelativeUrl")
+      case _ => throw new UriConversionException(getClass.getSimpleName + " cannot be converted to ProtocolRelativeUrl")
     }
 
   def toUrl: Url = this

--- a/shared/src/main/scala/io/lemonlabs/uri/config/UriConfig.scala
+++ b/shared/src/main/scala/io/lemonlabs/uri/config/UriConfig.scala
@@ -17,56 +17,6 @@ case class UriConfig(userInfoEncoder: UriEncoder,
                      defaultPorts: Map[String, Int]
 ) {
 
-  def this(userInfoEncoder: UriEncoder,
-           pathEncoder: UriEncoder,
-           queryEncoder: UriEncoder,
-           fragmentEncoder: UriEncoder,
-           userInfoDecoder: UriDecoder,
-           pathDecoder: UriDecoder,
-           queryDecoder: UriDecoder,
-           fragmentDecoder: UriDecoder,
-           charset: String,
-           renderQuery: RenderQuery
-  ) =
-    this(
-      userInfoEncoder,
-      pathEncoder,
-      queryEncoder,
-      fragmentEncoder,
-      userInfoDecoder,
-      pathDecoder,
-      queryDecoder,
-      fragmentDecoder,
-      charset,
-      renderQuery,
-      UriConfig.defaultPorts
-    )
-
-  def copy(userInfoEncoder: UriEncoder = this.userInfoEncoder,
-           pathEncoder: UriEncoder = this.pathEncoder,
-           queryEncoder: UriEncoder = this.queryEncoder,
-           fragmentEncoder: UriEncoder = this.fragmentEncoder,
-           userInfoDecoder: UriDecoder = this.userInfoDecoder,
-           pathDecoder: UriDecoder = this.pathDecoder,
-           queryDecoder: UriDecoder = this.queryDecoder,
-           fragmentDecoder: UriDecoder = this.fragmentDecoder,
-           charset: String = this.charset,
-           renderQuery: RenderQuery = this.renderQuery
-  ): UriConfig =
-    UriConfig(
-      userInfoEncoder,
-      pathEncoder,
-      queryEncoder,
-      fragmentEncoder,
-      userInfoDecoder,
-      pathDecoder,
-      queryDecoder,
-      fragmentDecoder,
-      charset,
-      renderQuery,
-      defaultPorts
-    )
-
   def withDefaultPorts(newDefaultPorts: Map[String, Int]): UriConfig =
     UriConfig(
       userInfoEncoder,

--- a/shared/src/main/scala/io/lemonlabs/uri/inet/PublicSuffixes.scala
+++ b/shared/src/main/scala/io/lemonlabs/uri/inet/PublicSuffixes.scala
@@ -1,7 +1,7 @@
 package io.lemonlabs.uri.inet
 
 object PublicSuffixes {
-  lazy val exceptions = Set(
+  lazy val exceptions: Set[String] = Set(
     "www.ck",
     "city.kawasaki.jp",
     "city.kitakyushu.jp",
@@ -12,7 +12,7 @@ object PublicSuffixes {
     "city.yokohama.jp"
   )
 
-  lazy val wildcardPrefixes = Set(
+  lazy val wildcardPrefixes: Set[String] = Set(
     "bd",
     "nom.br",
     "ck",
@@ -33,7 +33,7 @@ object PublicSuffixes {
     "sch.uk"
   )
 
-  lazy val set = publicSuffixes0 ++ publicSuffixes1
+  lazy val set: Set[String] = publicSuffixes0 ++ publicSuffixes1
   private def publicSuffixes0 =
     Set(
       "ac",
@@ -620,7 +620,6 @@ object PublicSuffixes {
       "md.ci",
       "gouv.ci",
       "cl",
-      "aprendemas.cl",
       "co.cl",
       "gob.cl",
       "gov.cl",
@@ -5035,11 +5034,11 @@ object PublicSuffixes {
       "org.pe",
       "com.pe",
       "net.pe",
-      "pf"
+      "pf",
+      "com.pf"
     )
   private def publicSuffixes1 =
     Set(
-      "com.pf",
       "org.pf",
       "edu.pf",
       "ph",
@@ -6011,6 +6010,7 @@ object PublicSuffixes {
       "edu.vc",
       "ve",
       "arts.ve",
+      "bib.ve",
       "co.ve",
       "com.ve",
       "e12.ve",
@@ -6022,7 +6022,9 @@ object PublicSuffixes {
       "int.ve",
       "mil.ve",
       "net.ve",
+      "nom.ve",
       "org.ve",
+      "rar.ve",
       "rec.ve",
       "store.ve",
       "tec.ve",
@@ -6721,6 +6723,7 @@ object PublicSuffixes {
       "kerryproperties",
       "kfh",
       "kia",
+      "kids",
       "kim",
       "kinder",
       "kindle",

--- a/shared/src/main/scala/io/lemonlabs/uri/inet/PublicSuffixes.scala
+++ b/shared/src/main/scala/io/lemonlabs/uri/inet/PublicSuffixes.scala
@@ -34,7 +34,7 @@ object PublicSuffixes {
   )
 
   lazy val set: Set[String] = publicSuffixes0 ++ publicSuffixes1
-  private def publicSuffixes0: Set[String] =
+  private def publicSuffixes0 =
     Set(
       "ac",
       "com.ac",
@@ -179,15 +179,19 @@ object PublicSuffixes {
       "it.ao",
       "aq",
       "ar",
+      "bet.ar",
       "com.ar",
+      "coop.ar",
       "edu.ar",
       "gob.ar",
       "gov.ar",
       "int.ar",
       "mil.ar",
       "musica.ar",
+      "mutual.ar",
       "net.ar",
       "org.ar",
+      "senasa.ar",
       "tur.ar",
       "arpa",
       "e164.arpa",
@@ -5031,14 +5035,14 @@ object PublicSuffixes {
       "gob.pe",
       "nom.pe",
       "mil.pe",
-      "org.pe",
+      "org.pe"
+    )
+  private def publicSuffixes1 =
+    Set(
       "com.pe",
       "net.pe",
       "pf",
-      "com.pf"
-    )
-  private def publicSuffixes1: Set[String] =
-    Set(
+      "com.pf",
       "org.pf",
       "edu.pf",
       "ph",

--- a/shared/src/main/scala/io/lemonlabs/uri/inet/PublicSuffixes.scala
+++ b/shared/src/main/scala/io/lemonlabs/uri/inet/PublicSuffixes.scala
@@ -34,7 +34,7 @@ object PublicSuffixes {
   )
 
   lazy val set: Set[String] = publicSuffixes0 ++ publicSuffixes1
-  private def publicSuffixes0 =
+  private def publicSuffixes0: Set[String] =
     Set(
       "ac",
       "com.ac",
@@ -5037,7 +5037,7 @@ object PublicSuffixes {
       "pf",
       "com.pf"
     )
-  private def publicSuffixes1 =
+  private def publicSuffixes1: Set[String] =
     Set(
       "org.pf",
       "edu.pf",

--- a/shared/src/main/scala/io/lemonlabs/uri/typesafe/Fragment.scala
+++ b/shared/src/main/scala/io/lemonlabs/uri/typesafe/Fragment.scala
@@ -71,7 +71,7 @@ sealed trait FragmentInstances1 extends FragmentInstances2 {
   implicit final val floatQueryValue: Fragment[Float] = stringFragment.contramap(_.toString)
   implicit final val doubleQueryValue: Fragment[Double] = stringFragment.contramap(_.toString)
   implicit final val uuidQueryValue: Fragment[java.util.UUID] = stringFragment.contramap(_.toString)
-  implicit val noneFragment: Fragment[None.type] = identity
+  implicit val noneFragment: Fragment[None.type] = _ => None
 }
 
 sealed trait FragmentInstances extends FragmentInstances1 {

--- a/shared/src/main/scala/io/lemonlabs/uri/typesafe/PathPart.scala
+++ b/shared/src/main/scala/io/lemonlabs/uri/typesafe/PathPart.scala
@@ -7,9 +7,6 @@ import simulacrum.typeclass
 
 import scala.language.implicitConversions
 import scala.annotation.implicitNotFound
-import scala.compiletime.package$package.{erasedValue, summonInline}
-import scala.deriving.Mirror
-import scala.deriving.*
 
 @implicitNotFound("Could not find an instance of PathPart for ${A}")
 @typeclass trait PathPart[-A] extends Serializable {
@@ -107,24 +104,7 @@ sealed trait TraversablePathPartsInstances {
     toSeq(a).toVector
 }
 
-object TraversablePathParts extends TraversablePathPartsInstances {
-  inline def product[A](implicit m: Mirror.ProductOf[A]): TraversablePathParts[A] = {
-    val elemInstances = summonAll[m.MirroredElemTypes]
-
-    new TraversablePathParts[A] {
-      override def toSeq(a: A): Seq[String] =
-        a.asInstanceOf[Product].productIterator.zip(elemInstances)
-          .flatMap { case (field, tc) => tc.asInstanceOf[TraversablePathParts[Any]].toSeq(field) }
-          .toSeq
-    }
-  }
-
-  inline private def summonAll[T <: Tuple]: List[TraversablePathParts[_]] =
-    inline erasedValue[T] match {
-      case _: EmptyTuple => Nil
-      case _: (t *: ts)  => summonInline[TraversablePathParts[t]] :: summonAll[ts]
-    }
-
+object TraversablePathParts extends TraversablePathPartsInstances with TraversablePathPartsDeriving {
   /* ======================================================================== */
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
   /* ======================================================================== */

--- a/shared/src/main/scala/io/lemonlabs/uri/typesafe/PathPart.scala
+++ b/shared/src/main/scala/io/lemonlabs/uri/typesafe/PathPart.scala
@@ -2,7 +2,7 @@ package io.lemonlabs.uri.typesafe
 
 import java.util.UUID
 import cats.Contravariant
-import cats.syntax.contravariant.*
+import cats.syntax.contravariant._
 import simulacrum.typeclass
 
 import scala.language.implicitConversions

--- a/shared/src/main/scala/io/lemonlabs/uri/typesafe/QueryKeyValue.scala
+++ b/shared/src/main/scala/io/lemonlabs/uri/typesafe/QueryKeyValue.scala
@@ -1,15 +1,13 @@
 package io.lemonlabs.uri.typesafe
 
 import cats.Contravariant
-import cats.syntax.contravariant._
-import shapeless._
-import shapeless.labelled._
-import shapeless.ops.coproduct.Reify
-import shapeless.ops.hlist.ToList
+import cats.syntax.contravariant.*
 import simulacrum.typeclass
 
 import scala.language.implicitConversions
 import scala.annotation.implicitNotFound
+import scala.compiletime.package$package.{erasedValue, summonInline, summonFrom}
+import scala.deriving.Mirror
 
 @implicitNotFound("Could not find an instance of QueryKey for ${A}")
 @typeclass trait QueryKey[A] extends Serializable {
@@ -83,13 +81,11 @@ sealed trait QueryKeyInstances extends QueryKeyInstances1 {
 }
 
 object QueryValue extends QueryValueInstances {
-  def derive[A]: Derivation[A] = new Derivation[A](())
+  def derive[A] = new Derivation[A](())
 
   class Derivation[A](private val dummy: Unit) extends AnyVal {
-    def by[C <: Coproduct, R <: HList](
-        key: A => String
-    )(implicit gen: Generic.Aux[A, C], reify: Reify.Aux[C, R], toList: ToList[R, A]): QueryValue[A] =
-      a => toList(reify()).iterator.map(x => x -> key(x)).toMap.get(a)
+    def by[B](f: A => B)(implicit qv: QueryValue[B]): QueryValue[A] =
+      a => qv.queryValue(f(a))
   }
 
   /* ======================================================================== */
@@ -232,26 +228,27 @@ sealed trait QueryKeyValueInstances {
 }
 
 object TraversableParams extends TraversableParamsInstances {
-  implicit def field[K <: Symbol, V](implicit K: Witness.Aux[K], V: QueryValue[V]): TraversableParams[FieldType[K, V]] =
-    (a: FieldType[K, V]) => List(K.value.name -> V.queryValue(a))
+  inline def product[A](implicit m: Mirror.ProductOf[A]): TraversableParams[A] = {
+    val elemInstances = summonAll[m.MirroredElemTypes]
 
-  implicit def sub[K <: Symbol, V](implicit
-      K: Witness.Aux[K],
-      V: TraversableParams[V]
-  ): TraversableParams[FieldType[K, V]] =
-    (a: FieldType[K, V]) => V.toSeq(a)
+    new TraversableParams[A] {
+      override def toSeq(a: A): Seq[(String, Option[String])] =
+        a.asInstanceOf[Product].productElementNames
+          .zip(a.asInstanceOf[Product].productIterator)
+          .zip(elemInstances)
+          .flatMap {
+            case ((name, field), tc : QueryValue[_]) => Seq((name, tc.asInstanceOf[QueryValue[Any]].queryValue(field)))
+            case ((name, field), tc : TraversableParams[_]) => tc.asInstanceOf[TraversableParams[Any]].toSeq(field)
+          }
+          .toSeq
+    }
+  }
 
-  implicit val hnil: TraversableParams[HNil] =
-    (_: HNil) => List.empty
-
-  implicit def hcons[H, T <: HList](implicit
-      H: TraversableParams[H],
-      T: TraversableParams[T]
-  ): TraversableParams[H :: T] =
-    (a: H :: T) => H.toSeq(a.head) ++ T.toSeq(a.tail)
-
-  def product[A, R <: HList](implicit gen: LabelledGeneric.Aux[A, R], R: TraversableParams[R]): TraversableParams[A] =
-    (a: A) => R.toSeq(gen.to(a))
+  inline private def summonAll[T <: Tuple]: List[QueryValue[_] | TraversableParams[_]] =
+    inline erasedValue[T] match {
+      case _: EmptyTuple => Nil
+      case _: (t *: ts)  => summonInline[TraversableParams[t] | QueryValue[t]] :: summonAll[ts]
+    }
 
   /* ======================================================================== */
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */

--- a/shared/src/main/scala/io/lemonlabs/uri/typesafe/QueryKeyValue.scala
+++ b/shared/src/main/scala/io/lemonlabs/uri/typesafe/QueryKeyValue.scala
@@ -1,7 +1,7 @@
 package io.lemonlabs.uri.typesafe
 
 import cats.Contravariant
-import cats.syntax.contravariant.*
+import cats.syntax.contravariant._
 import simulacrum.typeclass
 
 import scala.language.implicitConversions

--- a/shared/src/test/scala/io/lemonlabs/uri/CatsTests.scala
+++ b/shared/src/test/scala/io/lemonlabs/uri/CatsTests.scala
@@ -3,85 +3,81 @@ package io.lemonlabs.uri
 import org.scalatest.flatspec.AnyFlatSpec
 import cats.implicits._
 import org.scalatest.matchers.should.Matchers
-import cats.kernel.Comparison
+import cats.kernel.{Comparison, Eq}
 
 class CatsTests extends AnyFlatSpec with Matchers {
-  trait CatsTestCase {
-    val convertToEqualizer = () // shadow ScalaTest
-  }
-
-  "Eq" should "be supported for Uri" in new CatsTestCase {
+  "Eq" should "be supported for Uri" in {
     val uri = Uri.parse("https://typelevel.org/cats/")
     val uri2: Uri = AbsoluteUrl.parse("https://typelevel.org/cats/")
 
-    (uri === uri2) should equal(true)
+    (uri eqv uri2) should equal(true)
   }
 
-  it should "be supported for unordered query params Uri" in new CatsTestCase {
+  it should "be supported for unordered query params Uri" in {
     import Uri.unordered._
 
     val uri = Uri.parse("https://typelevel.org/cats/?a=1&b=two")
     val uri2: Uri = AbsoluteUrl.parse("https://typelevel.org/cats/?b=two&a=1")
 
-    (uri === uri2) should equal(true)
+    (uri eqv uri2) should equal(true)
   }
 
-  it should "be supported for Url" in new CatsTestCase {
+  it should "be supported for Url" in {
     val uri = Url.parse("https://typelevel.org/cats/")
     val uri2: Url = AbsoluteUrl.parse("https://typelevel.org/cats/")
 
-    (uri === uri2) should equal(true)
+    (uri eqv uri2) should equal(true)
   }
 
-  it should "be supported unordered query params Url" in new CatsTestCase {
+  it should "be supported unordered query params Url" in {
     import Url.unordered._
 
     val uri = Url.parse("https://typelevel.org/cats/?a=1&b=two")
     val uri2: Url = AbsoluteUrl.parse("https://typelevel.org/cats/?b=two&a=1")
 
-    (uri === uri2) should equal(true)
+    (uri eqv uri2) should equal(true)
   }
 
-  it should "be supported for RelativeUrl" in new CatsTestCase {
+  it should "be supported for RelativeUrl" in {
     val uri: Url = RelativeUrl.parse("/cats2/")
     val uri2: Url = RelativeUrl.parse("/cats/")
 
-    (uri === uri2) should equal(false)
+    (uri eqv uri2) should equal(false)
   }
 
-  it should "be supported for unordered query params RelativeUrl" in new CatsTestCase {
+  it should "be supported for unordered query params RelativeUrl" in {
     import RelativeUrl.unordered._
 
     val uri = RelativeUrl.parse("/cats2/?b=two&a=1")
     val uri2 = RelativeUrl.parse("/cats/?a=1&b=two")
 
-    (uri === uri2) should equal(false)
+    (uri eqv uri2) should equal(false)
   }
 
-  it should "be supported for UrlWithAuthority" in new CatsTestCase {
+  it should "be supported for UrlWithAuthority" in {
     val uri = UrlWithAuthority.parse("https://typelevel.org/cats/")
     val uri2: UrlWithAuthority = AbsoluteUrl.parse("https://typelevel.org/cats/")
 
-    (uri === uri2) should equal(true)
+    (uri eqv uri2) should equal(true)
   }
 
-  it should "be supported for unordered query params UrlWithAuthority" in new CatsTestCase {
+  it should "be supported for unordered query params UrlWithAuthority" in {
     import UrlWithAuthority.unordered._
 
     val uri = UrlWithAuthority.parse("https://typelevel.org/cats/?a=1&b=two")
     val uri2: UrlWithAuthority = AbsoluteUrl.parse("https://typelevel.org/cats/?b=two&a=1")
 
-    (uri === uri2) should equal(true)
+    (uri eqv uri2) should equal(true)
   }
 
-  it should "be supported for ProtocolRelativeUrl" in new CatsTestCase {
+  it should "be supported for ProtocolRelativeUrl" in {
     val uri = ProtocolRelativeUrl.parse("//typelevel.org/cats/")
     val uri2 = ProtocolRelativeUrl.parse("//typelevel.org/cats/?different=true")
 
     (uri =!= uri2) should equal(true)
   }
 
-  it should "be supported for unordered query params ProtocolRelativeUrl" in new CatsTestCase {
+  it should "be supported for unordered query params ProtocolRelativeUrl" in {
     import ProtocolRelativeUrl.unordered._
 
     val uri = ProtocolRelativeUrl.parse("//typelevel.org/cats/?b=two&a=1")
@@ -90,186 +86,186 @@ class CatsTests extends AnyFlatSpec with Matchers {
     (uri =!= uri2) should equal(false)
   }
 
-  it should "be supported for AbsoluteUrl" in new CatsTestCase {
+  it should "be supported for AbsoluteUrl" in {
     val uri = AbsoluteUrl.parse("https://typelevel.org/cats/")
     val uri2 = AbsoluteUrl.parse("https://typelevel.org/cats/")
 
-    (uri === uri2) should equal(true)
+    (uri eqv uri2) should equal(true)
   }
 
-  it should "be supported for unordered query params AbsoluteUrl" in new CatsTestCase {
+  it should "be supported for unordered query params AbsoluteUrl" in {
     import AbsoluteUrl.unordered._
 
     val uri = AbsoluteUrl.parse("https://typelevel.org/cats/?a=1&b=two")
     val uri2 = AbsoluteUrl.parse("https://typelevel.org/cats/?b=two&a=1")
 
-    (uri === uri2) should equal(true)
+    (uri eqv uri2) should equal(true)
   }
 
-  it should "be supported for UrlWithoutAuthority" in new CatsTestCase {
+  it should "be supported for UrlWithoutAuthority" in {
     val uri = UrlWithoutAuthority.parse("mailto:someone@somewhere.com")
     val uri2 = UrlWithoutAuthority.parse("mailto:someoneelse@somewhereelse.com")
 
-    (uri === uri2) should equal(false)
+    (uri eqv uri2) should equal(false)
   }
 
-  it should "be supported for unordered query params UrlWithoutAuthority" in new CatsTestCase {
+  it should "be supported for unordered query params UrlWithoutAuthority" in {
     import UrlWithoutAuthority.unordered._
 
     val uri = UrlWithoutAuthority.parse("mailto:someone@somewhere.com?b=two&a=1")
     val uri2 = UrlWithoutAuthority.parse("mailto:someoneelse@somewhereelse.com?a=1&b=two")
 
-    (uri === uri2) should equal(false)
+    (uri eqv uri2) should equal(false)
   }
 
-  it should "be supported for SimpleUrlWithoutAuthority" in new CatsTestCase {
+  it should "be supported for SimpleUrlWithoutAuthority" in {
     val uri = SimpleUrlWithoutAuthority.parse("mailto:someone@somewhere.com")
     val uri2 = SimpleUrlWithoutAuthority.parse("mailto:someone@somewhere.com")
 
-    (uri === uri2) should equal(true)
+    (uri eqv uri2) should equal(true)
   }
 
-  it should "be supported for unordered query params SimpleUrlWithoutAuthority" in new CatsTestCase {
+  it should "be supported for unordered query params SimpleUrlWithoutAuthority" in {
     import SimpleUrlWithoutAuthority.unordered._
 
     val uri = SimpleUrlWithoutAuthority.parse("mailto:someone@somewhere.com?a=1&b=two")
     val uri2 = SimpleUrlWithoutAuthority.parse("mailto:someone@somewhere.com?b=two&a=1")
 
-    (uri === uri2) should equal(true)
+    (uri eqv uri2) should equal(true)
   }
 
-  it should "be supported for DataUrl" in new CatsTestCase {
+  it should "be supported for DataUrl" in {
     val uri = DataUrl.parse("data:,A%20brief%20note")
     val uri2 = DataUrl.parse("data:,Another%20brief%20note")
 
     (uri =!= uri2) should equal(true)
   }
 
-  it should "be supported for ScpLikeUrl" in new CatsTestCase {
+  it should "be supported for ScpLikeUrl" in {
     val uri = ScpLikeUrl.parse("root@host:/root/file.tar.gz")
     val uri2 = ScpLikeUrl.parse("root@host:/root/file2.tar.gz")
 
     (uri =!= uri2) should equal(true)
   }
 
-  it should "be supported for Urn" in new CatsTestCase {
+  it should "be supported for Urn" in {
     val uri = Urn.parse("urn:cats:1")
     val uri2 = Urn.parse("urn:cats:2")
 
     (uri =!= uri2) should equal(true)
   }
 
-  it should "be supported for Authority" in new CatsTestCase {
+  it should "be supported for Authority" in {
     val authority = Authority.parse("typelevel.org:443")
     val authority2 = Authority.parse("typelevel.org:443")
 
-    (authority === authority2) should equal(true)
+    (authority eqv authority2) should equal(true)
   }
 
-  it should "be supported for UserInfo" in new CatsTestCase {
+  it should "be supported for UserInfo" in {
     val userInfo = UserInfo("user", "password")
     val userInfo2 = UserInfo("user", "password2")
 
     (userInfo =!= userInfo2) should equal(true)
   }
 
-  it should "be supported for Host" in new CatsTestCase {
+  it should "be supported for Host" in {
     val host = Host.parse("typelevel.org")
     val host2 = Host.parse("typelevel.org")
 
     (host =!= host2) should equal(false)
   }
 
-  it should "be supported for DomainName" in new CatsTestCase {
+  it should "be supported for DomainName" in {
     val host = DomainName.parse("typelevel.org")
     val host2 = DomainName.parse("www.typelevel.org")
 
     (host =!= host2) should equal(true)
   }
 
-  it should "be supported for Ipv4" in new CatsTestCase {
+  it should "be supported for Ipv4" in {
     val host = IpV4.parse("8.8.8.8")
     val host2 = IpV4.parse("8.8.8.8")
 
-    (host === host2) should equal(true)
+    (host eqv host2) should equal(true)
   }
 
-  it should "be supported for Ipv6" in new CatsTestCase {
+  it should "be supported for Ipv6" in {
     val host = IpV6.parse("[1f4:0:0:1e::1]")
     val host2 = IpV6.parse("[1f4:0:0:1e::1]")
 
-    (host === host2) should equal(true)
+    (host eqv host2) should equal(true)
   }
 
-  it should "be supported for MediaType" in new CatsTestCase {
+  it should "be supported for MediaType" in {
     val mediaType = MediaType("text/plain".some, Vector("charset" -> "utf8"))
     val mediaType2 = MediaType("text/plain".some, Vector.empty)
 
-    (mediaType === mediaType2) should equal(false)
+    (mediaType eqv mediaType2) should equal(false)
   }
 
-  it should "be supported for Path" in new CatsTestCase {
+  it should "be supported for Path" in {
     val path = Path.parse("/cats/")
     val path2 = Path.parse("/cats/")
 
-    (path === path2) should equal(true)
+    (path eqv path2) should equal(true)
   }
 
-  it should "be supported for UrlPath" in new CatsTestCase {
+  it should "be supported for UrlPath" in {
     val path = UrlPath.parse("/cats/")
     val path2 = UrlPath.parse("/cats/")
 
-    (path === path2) should equal(true)
+    (path eqv path2) should equal(true)
   }
 
-  it should "be supported for AbsoluteOrEmptyPath" in new CatsTestCase {
+  it should "be supported for AbsoluteOrEmptyPath" in {
     val path: AbsoluteOrEmptyPath = AbsolutePath.fromParts("cats")
     val path2: AbsoluteOrEmptyPath = AbsolutePath.fromParts("cats")
 
-    (path === path2) should equal(true)
+    (path eqv path2) should equal(true)
   }
 
-  it should "be supported for RootlessPath" in new CatsTestCase {
+  it should "be supported for RootlessPath" in {
     val path = RootlessPath.fromParts("cats")
     val path2 = RootlessPath.fromParts("cats2")
 
     (path =!= path2) should equal(true)
   }
 
-  it should "be supported for AbsolutePath" in new CatsTestCase {
+  it should "be supported for AbsolutePath" in {
     val path = AbsolutePath.fromParts("cats")
     val path2 = AbsolutePath.fromParts("cats")
 
-    (path === path2) should equal(true)
+    (path eqv path2) should equal(true)
   }
 
-  it should "be supported for UrnPath" in new CatsTestCase {
+  it should "be supported for UrnPath" in {
     val path = UrnPath.parse("cats:1")
     val path2 = UrnPath.parse("cats:2")
 
     (path =!= path2) should equal(true)
   }
 
-  it should "be supported for QueryString" in new CatsTestCase {
+  it should "be supported for QueryString" in {
     val qs = QueryString.parse("a=1&b=2")
     val qs2 = QueryString.parse("a=1&b=2")
 
-    (qs === qs2) should equal(true)
+    (qs eqv qs2) should equal(true)
   }
 
-  it should "be supported for unordered QueryString" in new CatsTestCase {
+  it should "be supported for unordered QueryString" in {
     val qs = QueryString.parse("a=1&b=2")
     val qs2 = QueryString.parse("b=2&a=1")
 
     import QueryString.unordered._
-    (qs === qs2) should equal(true)
+    (qs eqv qs2) should equal(true)
   }
 
-  it should "be supported for ordered QueryString" in new CatsTestCase {
+  it should "be supported for ordered QueryString" in {
     val qs = QueryString.parse("a=1&b=2")
     val qs2 = QueryString.parse("b=2&a=1")
 
-    (qs === qs2) should equal(false)
+    (qs eqv qs2) should equal(false)
   }
 
   "Show" should "be supported for Uri" in {
@@ -392,145 +388,145 @@ class CatsTests extends AnyFlatSpec with Matchers {
     qs.show should equal("a=1&b=2")
   }
 
-  "Order" should "be supported for Uri" in new CatsTestCase {
+  "Order" should "be supported for Uri" in {
     val uri = Uri.parse("https://typelevel.org/cats2/")
     val uri2: Uri = AbsoluteUrl.parse("https://typelevel.org/cats/")
     (uri comparison uri2) should equal(Comparison.GreaterThan)
   }
 
-  it should "be supported for Url" in new CatsTestCase {
+  it should "be supported for Url" in {
     val uri = Url.parse("https://typelevel.org/cats/")
     val uri2: Url = AbsoluteUrl.parse("https://typelevel.org/cats/")
     (uri comparison uri2) should equal(Comparison.EqualTo)
   }
 
-  it should "be supported for RelativeUrl" in new CatsTestCase {
+  it should "be supported for RelativeUrl" in {
     val uri: Url = RelativeUrl.parse("/cats2/")
     val uri2: Url = RelativeUrl.parse("/cats/")
     (uri comparison uri2) should equal(Comparison.GreaterThan)
   }
 
-  it should "be supported for UrlWithAuthority" in new CatsTestCase {
+  it should "be supported for UrlWithAuthority" in {
     val uri = UrlWithAuthority.parse("https://typelevel.org/cats/")
     val uri2: UrlWithAuthority = AbsoluteUrl.parse("https://typelevel.org/cats/")
     (uri comparison uri2) should equal(Comparison.EqualTo)
   }
 
-  it should "be supported for ProtocolRelativeUrl" in new CatsTestCase {
+  it should "be supported for ProtocolRelativeUrl" in {
     val uri = ProtocolRelativeUrl.parse("//typelevel.org/cats/")
     val uri2 = ProtocolRelativeUrl.parse("//typelevel.org/cats/?different=true")
     (uri comparison uri2) should equal(Comparison.LessThan)
   }
 
-  it should "be supported for AbsoluteUrl" in new CatsTestCase {
+  it should "be supported for AbsoluteUrl" in {
     val uri = AbsoluteUrl.parse("https://typelevel.org/cats/")
     val uri2 = AbsoluteUrl.parse("https://typelevel.org/cats/")
     (uri comparison uri2) should equal(Comparison.EqualTo)
   }
 
-  it should "be supported for UrlWithoutAuthority" in new CatsTestCase {
+  it should "be supported for UrlWithoutAuthority" in {
     val uri = UrlWithoutAuthority.parse("mailto:someone@somewhere.com")
     val uri2 = UrlWithoutAuthority.parse("mailto:someoneelse@somewhereelse.com")
     (uri comparison uri2) should equal(Comparison.LessThan)
   }
 
-  it should "be supported for SimpleUrlWithoutAuthority" in new CatsTestCase {
+  it should "be supported for SimpleUrlWithoutAuthority" in {
     val uri = SimpleUrlWithoutAuthority.parse("mailto:someone@somewhere.com")
     val uri2 = SimpleUrlWithoutAuthority.parse("mailto:someone@somewhere.com")
     (uri comparison uri2) should equal(Comparison.EqualTo)
   }
 
-  it should "be supported for DataUrl" in new CatsTestCase {
+  it should "be supported for DataUrl" in {
     val uri = DataUrl.parse("data:text;,A%20brief%20note")
     val uri2 = DataUrl.parse("data:text;base64,R0lGODdh")
     (uri comparison uri2) should equal(Comparison.LessThan)
   }
 
-  "Order" should "be supported for Urn" in new CatsTestCase {
+  "Order" should "be supported for Urn" in {
     val uri = Urn.parse("urn:cats:1")
     val uri2 = Urn.parse("urn:cats:2")
     (uri comparison uri2) should equal(Comparison.LessThan)
   }
 
-  it should "be supported for Authority" in new CatsTestCase {
+  it should "be supported for Authority" in {
     val authority = Authority.parse("typelevel.org:443")
     val authority2 = Authority.parse("typelevel.org:443")
     (authority comparison authority2) should equal(Comparison.EqualTo)
   }
 
-  it should "be supported for UserInfo" in new CatsTestCase {
+  it should "be supported for UserInfo" in {
     val userInfo = UserInfo("user", "password")
     val userInfo2 = UserInfo("user", "password2")
     (userInfo comparison userInfo2) should equal(Comparison.LessThan)
   }
 
-  it should "be supported for Host" in new CatsTestCase {
+  it should "be supported for Host" in {
     val host = Host.parse("typelevel.org")
     val host2 = Host.parse("typelevel.org")
     (host comparison host2) should equal(Comparison.EqualTo)
   }
 
-  it should "be supported for DomainName" in new CatsTestCase {
+  it should "be supported for DomainName" in {
     val host = DomainName.parse("typelevel.org")
     val host2 = DomainName.parse("www.typelevel.org")
     (host comparison host2) should equal(Comparison.LessThan)
   }
 
-  it should "be supported for Ipv4" in new CatsTestCase {
+  it should "be supported for Ipv4" in {
     val host = IpV4.parse("8.8.8.8")
     val host2 = IpV4.parse("8.8.8.8")
     (host comparison host2) should equal(Comparison.EqualTo)
   }
 
-  it should "be supported for Ipv6" in new CatsTestCase {
+  it should "be supported for Ipv6" in {
     val host = IpV6.parse("[1f4:0:0:1e::1]")
     val host2 = IpV6.parse("[1f4:0:0:1e::1]")
     (host comparison host2) should equal(Comparison.EqualTo)
   }
 
-  it should "be supported for MediaType" in new CatsTestCase {
+  it should "be supported for MediaType" in {
     val mediaType = MediaType("text/plain".some, Vector("charset" -> "utf8"))
     val mediaType2 = MediaType("text/plain".some, Vector.empty)
     (mediaType comparison mediaType2) should equal(Comparison.GreaterThan)
   }
 
-  it should "be supported for Path" in new CatsTestCase {
+  it should "be supported for Path" in {
     val path = Path.parse("/cats/")
     val path2 = Path.parse("/cats/")
     (path comparison path2) should equal(Comparison.EqualTo)
   }
 
-  it should "be supported for UrlPath" in new CatsTestCase {
+  it should "be supported for UrlPath" in {
     val path = UrlPath.parse("/cats/")
     val path2 = UrlPath.parse("/cats/")
     (path comparison path2) should equal(Comparison.EqualTo)
   }
 
-  it should "be supported for AbsoluteOrEmptyPath" in new CatsTestCase {
+  it should "be supported for AbsoluteOrEmptyPath" in {
     val path: AbsoluteOrEmptyPath = AbsolutePath.fromParts("cats")
     val path2: AbsoluteOrEmptyPath = AbsolutePath.fromParts("cats")
     (path comparison path2) should equal(Comparison.EqualTo)
   }
 
-  it should "be supported for RootlessPath" in new CatsTestCase {
+  it should "be supported for RootlessPath" in {
     val path = RootlessPath.fromParts("cats")
     val path2 = RootlessPath.fromParts("cats2")
     (path comparison path2) should equal(Comparison.LessThan)
   }
 
-  it should "be supported for AbsolutePath" in new CatsTestCase {
+  it should "be supported for AbsolutePath" in {
     val path = AbsolutePath.fromParts("cats")
     val path2 = AbsolutePath.fromParts("cats")
     (path comparison path2) should equal(Comparison.EqualTo)
   }
 
-  it should "be supported for UrnPath" in new CatsTestCase {
+  it should "be supported for UrnPath" in {
     val path = UrnPath.parse("cats:1")
     val path2 = UrnPath.parse("cats:2")
     (path comparison path2) should equal(Comparison.LessThan)
   }
 
-  it should "be supported for QueryString" in new CatsTestCase {
+  it should "be supported for QueryString" in {
     val qs = QueryString.parse("a=1&b=2")
     val qs2 = QueryString.parse("a=1&b=2")
     (qs comparison qs2) should equal(Comparison.EqualTo)

--- a/shared/src/test/scala/io/lemonlabs/uri/ConfigTests.scala
+++ b/shared/src/test/scala/io/lemonlabs/uri/ConfigTests.scala
@@ -14,7 +14,7 @@ import org.scalatest.matchers.should.Matchers
 
 class ConfigTests extends AnyFlatSpec with Matchers {
   "Config constructor without defaultPorts" should "use the default defaultPorts" in {
-    val conf = new UriConfig(
+    val conf = UriConfig(
       userInfoEncoder = PercentEncoder(USER_INFO_CHARS_TO_ENCODE),
       pathEncoder = PercentEncoder(PATH_CHARS_TO_ENCODE),
       queryEncoder = PercentEncoder(QUERY_CHARS_TO_ENCODE),

--- a/shared/src/test/scala/io/lemonlabs/uri/EncodingTests.scala
+++ b/shared/src/test/scala/io/lemonlabs/uri/EncodingTests.scala
@@ -30,7 +30,7 @@ class EncodingTests extends AnyFlatSpec with Matchers {
 
   "URI path double quotes" should "be percent encoded when using conservative encoder" in {
     val url = Url.parse("""http://theon.github.com/blah/"quoted"""")
-    url.toString(UriConfig.conservative) should equal("http://theon.github.com/blah/%22quoted%22")
+    url.toStringWithConfig(UriConfig.conservative) should equal("http://theon.github.com/blah/%22quoted%22")
   }
 
   "URI path spaces" should "be plus encoded if configured" in {
@@ -53,14 +53,14 @@ class EncodingTests extends AnyFlatSpec with Matchers {
 
   "Querystring double quotes" should "be percent encoded when using conservative encoder" in {
     val url = Url.parse("""http://theon.github.com?blah="quoted"""")
-    url.toString(UriConfig.conservative) should equal("http://theon.github.com?blah=%22quoted%22")
+    url.toStringWithConfig(UriConfig.conservative) should equal("http://theon.github.com?blah=%22quoted%22")
   }
 
   "Reserved characters" should "be percent encoded when using conservative encoder" in {
     val url = Url(
       query = QueryString.fromPairs("reserved" -> ":/?#[]@!$&'()*+,;={}\\\n\r")
     )
-    url.toString(UriConfig.conservative) should equal(
+    url.toStringWithConfig(UriConfig.conservative) should equal(
       "?reserved=%3A%2F%3F%23%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D%7B%7D%5C%0A%0D"
     )
   }

--- a/shared/src/test/scala/io/lemonlabs/uri/EqualityTests.scala
+++ b/shared/src/test/scala/io/lemonlabs/uri/EqualityTests.scala
@@ -96,7 +96,7 @@ class EqualityTests extends AnyFlatSpec with Matchers with ScalaCheckDrivenPrope
   }
 
   "DataUrl.equals" should "equal itself" in new UriScalaCheckGenerators {
-    forAll { dataUrl: DataUrl =>
+    forAll { (dataUrl: DataUrl) =>
       (dataUrl == dataUrl) should equal(true)
     }
   }
@@ -108,7 +108,7 @@ class EqualityTests extends AnyFlatSpec with Matchers with ScalaCheckDrivenPrope
   }
 
   "DataUrl.hashCode" should "equal itself" in new UriScalaCheckGenerators {
-    forAll { dataUrl: DataUrl =>
+    forAll { (dataUrl: DataUrl) =>
       dataUrl.hashCode() should equal(dataUrl.hashCode())
     }
   }

--- a/shared/src/test/scala/io/lemonlabs/uri/NapGithubIssueTests.scala
+++ b/shared/src/test/scala/io/lemonlabs/uri/NapGithubIssueTests.scala
@@ -15,7 +15,7 @@ import org.scalatest.matchers.should.Matchers
 class NapGithubIssueTests extends AnyFlatSpec with Matchers with OptionValues {
   "Github Issue #2" should "now be fixed. Pluses in querystrings should be encoded when using the conservative encoder" in {
     val uri = Url.parse("http://theon.github.com/").addParam("+", "+")
-    uri.toString(UriConfig.conservative) should equal("http://theon.github.com/?%2B=%2B")
+    uri.toStringWithConfig(UriConfig.conservative) should equal("http://theon.github.com/?%2B=%2B")
   }
 
   "Github Issue #4" should "now be fixed. Port numbers should be rendered by toString" in {

--- a/shared/src/test/scala/io/lemonlabs/uri/ToUriTests.scala
+++ b/shared/src/test/scala/io/lemonlabs/uri/ToUriTests.scala
@@ -71,7 +71,7 @@ class ToUriTests extends AnyWordSpec with Matchers {
       url.password should equal(Some("password"))
       url.path.toString() should equal("/test")
       url.query.params should equal(Vector(("weird=&key", Some("strange%value")), ("arrow", Some("⇔"))))
-      url.toString(UriConfig.conservative) should equal(javaUri.toASCIIString)
+      url.toStringWithConfig(UriConfig.conservative) should equal(javaUri.toASCIIString)
     }
   }
 }

--- a/shared/src/test/scala/io/lemonlabs/uri/TypeClassTests.scala
+++ b/shared/src/test/scala/io/lemonlabs/uri/TypeClassTests.scala
@@ -59,6 +59,11 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
     uri.toString should equal("/a/5")
   }
 
+  "None" should "render correctly as a Fragment" in {
+    val uri = Url.parse("/a").withFragment(None)
+    uri.toString should equal("/a")
+  }
+
   "Foo" should "render correctly as path part" in {
     final case class Foo(a: String, b: Int)
     implicit val pathPart: TraversablePathParts[Foo] = TraversablePathParts.product

--- a/shared/src/test/scala/io/lemonlabs/uri/TypeClassTests.scala
+++ b/shared/src/test/scala/io/lemonlabs/uri/TypeClassTests.scala
@@ -62,8 +62,7 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
   "Foo" should "render correctly as path part" in {
     final case class Foo(a: String, b: Int)
     object Foo {
-      implicit val pathPart: TraversablePathParts[Foo] =
-        TraversablePathParts.product
+      given pathPart: TraversablePathParts[Foo] = TraversablePathParts.product
     }
 
     val uri = Url.parse("http://example.com") addPathParts Foo(a = "user", b = 1)
@@ -73,7 +72,7 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
   "Foo" should "render correctly as fragment" in {
     final case class Foo(a: String, b: Int)
     object Foo {
-      implicit val pathPart: Fragment[Foo] = (foo: Foo) => Some(s"${foo.a}-${foo.b}")
+      given pathPart: Fragment[Foo] = (foo: Foo) => Some(s"${foo.a}-${foo.b}")
     }
 
     val uri = Url.parse("/uris-in-scala.html") withFragment Foo(a = "user", b = 1)
@@ -83,7 +82,7 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
   "Foo" should "render correctly as query parameters" in {
     final case class Foo(a: String)
     object Foo {
-      implicit val fooQueryKeyValue: QueryKeyValue[Foo] = QueryKeyValue(_ => "foo", foo => Option(foo.a))
+      given fooQueryKeyValue: QueryKeyValue[Foo] = QueryKeyValue(_ => "foo", foo => Option(foo.a))
     }
 
     val uri = Url.parse("/uris-in-scala.html") addParam Foo("foo_value")
@@ -94,7 +93,7 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
     final case class Foo(a: Int, b: String)
 
     object Foo {
-      implicit val traversablePathParts: TraversablePathParts[Foo] = TraversablePathParts.product
+      given traversablePathParts: TraversablePathParts[Foo] = TraversablePathParts.product
     }
 
     val uri = Url.parse("/uris-in-scala") addPathParts Foo(a = 1, b = "bar")
@@ -105,13 +104,13 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
     final case class Foo(a: Int, b: String)
 
     object Foo {
-      implicit val traversablePathParts: TraversablePathParts[Foo] = TraversablePathParts.product
+      given traversablePathParts: TraversablePathParts[Foo] = TraversablePathParts.product
     }
 
     final case class Bar(c: Int, foo: Foo)
 
     object Bar {
-      implicit val traversablePathParts: TraversablePathParts[Bar] = TraversablePathParts.product
+      given traversablePathParts: TraversablePathParts[Bar] = TraversablePathParts.product
     }
 
     val uri = Url.parse("/uris-in-scala") addPathParts Bar(c = 2, foo = Foo(a = 1, b = "bar"))
@@ -122,7 +121,7 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
     final case class Foo(a: Int, b: Option[String])
 
     object Foo {
-      implicit val traversablePathParts: TraversablePathParts[Foo] = TraversablePathParts.product
+      given traversablePathParts: TraversablePathParts[Foo] = TraversablePathParts.product
     }
 
     val uriWithB = Url.parse("/uris-in-scala") addPathParts Foo(a = 1, b = Some("bar"))
@@ -135,7 +134,7 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
     final case class Foo(a: Int, b: String)
 
     object Foo {
-      implicit val traversablePathParts: TraversablePathParts[Foo] = TraversablePathParts.product
+      given traversablePathParts: TraversablePathParts[Foo] = TraversablePathParts.product
     }
 
     val uri = Url.parse("/uris-in-scala") withPathParts Foo(a = 1, b = "bar")
@@ -146,13 +145,13 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
     final case class Foo(a: Int, b: String)
 
     object Foo {
-      implicit val traversablePathParts: TraversablePathParts[Foo] = TraversablePathParts.product
+      given traversablePathParts: TraversablePathParts[Foo] = TraversablePathParts.product
     }
 
     final case class Bar(c: Int, foo: Foo)
 
     object Bar {
-      implicit val traversablePathParts: TraversablePathParts[Bar] = TraversablePathParts.product
+      given traversablePathParts: TraversablePathParts[Bar] = TraversablePathParts.product
     }
 
     val uri = Url.parse("/uris-in-scala") withPathParts Bar(c = 2, foo = Foo(a = 1, b = "bar"))
@@ -163,7 +162,7 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
     final case class Foo(a: Int, b: Option[String])
 
     object Foo {
-      implicit val traversablePathParts: TraversablePathParts[Foo] = TraversablePathParts.product
+      given traversablePathParts: TraversablePathParts[Foo] = TraversablePathParts.product
     }
 
     val uriWithB = Url.parse("/uris-in-scala") withPathParts Foo(a = 1, b = Some("bar"))
@@ -201,7 +200,7 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
     final case class Foo(a: Int, b: String)
 
     object Foo {
-      implicit val traversableParams: TraversableParams[Foo] = TraversableParams.product
+      given traversableParams: TraversableParams[Foo] = TraversableParams.product
     }
 
     val uri = Url.parse("/uris-in-scala.html") addParams Foo(a = 1, b = "bar")
@@ -212,13 +211,13 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
     final case class Foo(a: Int, b: String)
 
     object Foo {
-      implicit val traversableParams: TraversableParams[Foo] = TraversableParams.product
+      given traversableParams: TraversableParams[Foo] = TraversableParams.product
     }
 
     final case class Bar(c: Int, foo: Foo)
 
     object Bar {
-      implicit val traversableParams: TraversableParams[Bar] = TraversableParams.product
+      given traversableParams: TraversableParams[Bar] = TraversableParams.product
     }
 
     val uri = Url.parse("/uris-in-scala.html") addParams Bar(c = 2, foo = Foo(a = 1, b = "bar"))
@@ -229,7 +228,7 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
     final case class Foo(a: Int, b: Option[String])
 
     object Foo {
-      implicit val traversableParams: TraversableParams[Foo] = TraversableParams.product
+      given traversableParams: TraversableParams[Foo] = TraversableParams.product
     }
 
     val uriWithB = Url.parse("/uris-in-scala.html") addParams Foo(a = 1, b = Some("bar"))
@@ -238,7 +237,7 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
     uriWithoutB.toString should equal("/uris-in-scala.html?a=1&b")
 
     {
-      implicit val config: UriConfig = UriConfig(renderQuery = ExcludeNones)
+      given config: UriConfig = UriConfig(renderQuery = ExcludeNones)
       val uriWithBexludingNones = Url.parse("/uris-in-scala.html") addParams Foo(a = 1, b = Some("bar"))
       val uriWithoutBexludingNones = Url.parse("/uris-in-scala.html") addParams Foo(a = 1, b = None)
       uriWithBexludingNones.toString should equal("/uris-in-scala.html?a=1&b=bar")
@@ -260,7 +259,7 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
     }
 
     object Foo {
-      implicit val queryValue: QueryValue[Foo] = QueryValue.derive[Foo].by(_.name)
+      given queryValue: QueryValue[Foo] = QueryValue.derive[Foo].by(_.name)
     }
 
     val uriA = Url.parse("/uris-in-scala.html") addParam ("foo" -> A)

--- a/shared/src/test/scala/io/lemonlabs/uri/TypeClassTests.scala
+++ b/shared/src/test/scala/io/lemonlabs/uri/TypeClassTests.scala
@@ -61,9 +61,7 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
 
   "Foo" should "render correctly as path part" in {
     final case class Foo(a: String, b: Int)
-    object Foo {
-      given pathPart: TraversablePathParts[Foo] = TraversablePathParts.product
-    }
+    implicit val pathPart: TraversablePathParts[Foo] = TraversablePathParts.product
 
     val uri = Url.parse("http://example.com") addPathParts Foo(a = "user", b = 1)
     uri.toString should equal("http://example.com/user/1")
@@ -71,9 +69,7 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
 
   "Foo" should "render correctly as fragment" in {
     final case class Foo(a: String, b: Int)
-    object Foo {
-      given pathPart: Fragment[Foo] = (foo: Foo) => Some(s"${foo.a}-${foo.b}")
-    }
+    implicit val pathPart: Fragment[Foo] = (foo: Foo) => Some(s"${foo.a}-${foo.b}")
 
     val uri = Url.parse("/uris-in-scala.html") withFragment Foo(a = "user", b = 1)
     uri.toString should equal("/uris-in-scala.html#user-1")
@@ -81,9 +77,7 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
 
   "Foo" should "render correctly as query parameters" in {
     final case class Foo(a: String)
-    object Foo {
-      given fooQueryKeyValue: QueryKeyValue[Foo] = QueryKeyValue(_ => "foo", foo => Option(foo.a))
-    }
+    implicit val fooQueryKeyValue: QueryKeyValue[Foo] = QueryKeyValue(_ => "foo", foo => Option(foo.a))
 
     val uri = Url.parse("/uris-in-scala.html") addParam Foo("foo_value")
     uri.toString should equal("/uris-in-scala.html?foo=foo_value")
@@ -91,10 +85,7 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
 
   "addPathParts(TraversablePathParts)" should "derive type class for case class correctly" in {
     final case class Foo(a: Int, b: String)
-
-    object Foo {
-      given traversablePathParts: TraversablePathParts[Foo] = TraversablePathParts.product
-    }
+    implicit val traversablePathParts: TraversablePathParts[Foo] = TraversablePathParts.product
 
     val uri = Url.parse("/uris-in-scala") addPathParts Foo(a = 1, b = "bar")
     uri.toString should equal("/uris-in-scala/1/bar")
@@ -102,16 +93,10 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
 
   "addPathParts(TraversablePathParts)" should "derive type class for case classes structure correctly" in {
     final case class Foo(a: Int, b: String)
-
-    object Foo {
-      given traversablePathParts: TraversablePathParts[Foo] = TraversablePathParts.product
-    }
+    implicit val traversablePathPartsFoo: TraversablePathParts[Foo] = TraversablePathParts.product
 
     final case class Bar(c: Int, foo: Foo)
-
-    object Bar {
-      given traversablePathParts: TraversablePathParts[Bar] = TraversablePathParts.product
-    }
+    implicit val traversablePathPartsBar: TraversablePathParts[Bar] = TraversablePathParts.product
 
     val uri = Url.parse("/uris-in-scala") addPathParts Bar(c = 2, foo = Foo(a = 1, b = "bar"))
     uri.toString should equal("/uris-in-scala/2/1/bar")
@@ -119,10 +104,7 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
 
   "addPathParts(TraversablePathParts)" should "derive type class for case class with optional field correctly" in {
     final case class Foo(a: Int, b: Option[String])
-
-    object Foo {
-      given traversablePathParts: TraversablePathParts[Foo] = TraversablePathParts.product
-    }
+    implicit val traversablePathParts: TraversablePathParts[Foo] = TraversablePathParts.product
 
     val uriWithB = Url.parse("/uris-in-scala") addPathParts Foo(a = 1, b = Some("bar"))
     val uriWithoutB = Url.parse("/uris-in-scala") addPathParts Foo(a = 1, b = None)
@@ -132,10 +114,7 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
 
   "withPathParts(TraversablePathParts)" should "derive type class for case class correctly" in {
     final case class Foo(a: Int, b: String)
-
-    object Foo {
-      given traversablePathParts: TraversablePathParts[Foo] = TraversablePathParts.product
-    }
+    implicit val traversablePathParts: TraversablePathParts[Foo] = TraversablePathParts.product
 
     val uri = Url.parse("/uris-in-scala") withPathParts Foo(a = 1, b = "bar")
     uri.toString should equal("/1/bar")
@@ -143,16 +122,10 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
 
   "withPathParts(TraversablePathParts)" should "derive type class for case classes structure correctly" in {
     final case class Foo(a: Int, b: String)
-
-    object Foo {
-      given traversablePathParts: TraversablePathParts[Foo] = TraversablePathParts.product
-    }
+    implicit val traversablePathPartsFoo: TraversablePathParts[Foo] = TraversablePathParts.product
 
     final case class Bar(c: Int, foo: Foo)
-
-    object Bar {
-      given traversablePathParts: TraversablePathParts[Bar] = TraversablePathParts.product
-    }
+    implicit val traversablePathPartsBar: TraversablePathParts[Bar] = TraversablePathParts.product
 
     val uri = Url.parse("/uris-in-scala") withPathParts Bar(c = 2, foo = Foo(a = 1, b = "bar"))
     uri.toString should equal("/2/1/bar")
@@ -160,10 +133,7 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
 
   "withPathParts(TraversablePathParts)" should "derive type class for case class with optional field correctly" in {
     final case class Foo(a: Int, b: Option[String])
-
-    object Foo {
-      given traversablePathParts: TraversablePathParts[Foo] = TraversablePathParts.product
-    }
+    implicit val traversablePathPartsFoo: TraversablePathParts[Foo] = TraversablePathParts.product
 
     val uriWithB = Url.parse("/uris-in-scala") withPathParts Foo(a = 1, b = Some("bar"))
     val uriWithoutB = Url.parse("/uris-in-scala") withPathParts Foo(a = 1, b = None)
@@ -198,10 +168,7 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
 
   "TraversableParams" should "derive type class for case class correctly" in {
     final case class Foo(a: Int, b: String)
-
-    object Foo {
-      given traversableParams: TraversableParams[Foo] = TraversableParams.product
-    }
+    implicit val traversableParamsFoo: TraversableParams[Foo] = TraversableParams.product
 
     val uri = Url.parse("/uris-in-scala.html") addParams Foo(a = 1, b = "bar")
     uri.toString should equal("/uris-in-scala.html?a=1&b=bar")
@@ -209,16 +176,10 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
 
   "TraversableParams" should "derive type class for case classes structure correctly" in {
     final case class Foo(a: Int, b: String)
-
-    object Foo {
-      given traversableParams: TraversableParams[Foo] = TraversableParams.product
-    }
+    implicit val traversableParamsFoo: TraversableParams[Foo] = TraversableParams.product
 
     final case class Bar(c: Int, foo: Foo)
-
-    object Bar {
-      given traversableParams: TraversableParams[Bar] = TraversableParams.product
-    }
+    implicit val traversableParamsBar: TraversableParams[Bar] = TraversableParams.product
 
     val uri = Url.parse("/uris-in-scala.html") addParams Bar(c = 2, foo = Foo(a = 1, b = "bar"))
     uri.toString should equal("/uris-in-scala.html?c=2&a=1&b=bar")
@@ -226,10 +187,7 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
 
   "TraversableParams" should "derive type class for case class with optional field correctly" in {
     final case class Foo(a: Int, b: Option[String])
-
-    object Foo {
-      given traversableParams: TraversableParams[Foo] = TraversableParams.product
-    }
+    implicit val traversableParamsFoo: TraversableParams[Foo] = TraversableParams.product
 
     val uriWithB = Url.parse("/uris-in-scala.html") addParams Foo(a = 1, b = Some("bar"))
     val uriWithoutB = Url.parse("/uris-in-scala.html") addParams Foo(a = 1, b = None)
@@ -237,7 +195,7 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
     uriWithoutB.toString should equal("/uris-in-scala.html?a=1&b")
 
     {
-      given config: UriConfig = UriConfig(renderQuery = ExcludeNones)
+      implicit val config: UriConfig = UriConfig(renderQuery = ExcludeNones)
       val uriWithBexludingNones = Url.parse("/uris-in-scala.html") addParams Foo(a = 1, b = Some("bar"))
       val uriWithoutBexludingNones = Url.parse("/uris-in-scala.html") addParams Foo(a = 1, b = None)
       uriWithBexludingNones.toString should equal("/uris-in-scala.html?a=1&b=bar")
@@ -258,9 +216,7 @@ class TypeClassTests extends AnyFlatSpec with Matchers {
       val name: String = "B"
     }
 
-    object Foo {
-      given queryValue: QueryValue[Foo] = QueryValue.derive[Foo].by(_.name)
-    }
+    implicit val queryValue: QueryValue[Foo] = QueryValue.derive[Foo].by(_.name)
 
     val uriA = Url.parse("/uris-in-scala.html") addParam ("foo" -> A)
     val uriB = Url.parse("/uris-in-scala.html") addParam ("foo" -> B)

--- a/shared/src/test/scala/io/lemonlabs/uri/TypesafeDslTypeTests.scala
+++ b/shared/src/test/scala/io/lemonlabs/uri/TypesafeDslTypeTests.scala
@@ -2,8 +2,6 @@ package io.lemonlabs.uri
 
 import io.lemonlabs.uri.config.{ExcludeNones, UriConfig}
 import io.lemonlabs.uri.typesafe._
-import shapeless._
-import shapeless.labelled._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -38,7 +36,7 @@ class TypesafeDslTypeTests extends AnyFlatSpec with Matchers {
   "Foo" should "render correctly as path part" in {
     final case class Foo(a: String, b: Int)
     object Foo {
-      implicit val pathPart: TraversablePathParts[Foo] =
+      given pathPart: TraversablePathParts[Foo] =
         TraversablePathParts.product
     }
 
@@ -70,7 +68,7 @@ class TypesafeDslTypeTests extends AnyFlatSpec with Matchers {
     final case class Foo(a: Int, b: String)
 
     object Foo {
-      implicit val traversableParams: TraversableParams[Foo] = TraversableParams.product
+      given traversableParams: TraversableParams[Foo] = TraversableParams.product
     }
 
     val uri = "/uris-in-scala.html" addParams Foo(a = 1, b = "bar")
@@ -81,13 +79,13 @@ class TypesafeDslTypeTests extends AnyFlatSpec with Matchers {
     final case class Foo(a: Int, b: String)
 
     object Foo {
-      implicit val traversableParams: TraversableParams[Foo] = TraversableParams.product
+      given traversableParams: TraversableParams[Foo] = TraversableParams.product
     }
 
     final case class Bar(c: Int, foo: Foo)
 
     object Bar {
-      implicit val traversableParams: TraversableParams[Bar] = TraversableParams.product
+      given traversableParams: TraversableParams[Bar] = TraversableParams.product
     }
 
     val uri = "/uris-in-scala.html" addParams Bar(c = 2, foo = Foo(a = 1, b = "bar"))
@@ -98,7 +96,7 @@ class TypesafeDslTypeTests extends AnyFlatSpec with Matchers {
     final case class Foo(a: Int, b: Option[String])
 
     object Foo {
-      implicit val traversableParams: TraversableParams[Foo] = TraversableParams.product
+      given traversableParams: TraversableParams[Foo] = TraversableParams.product
     }
 
     val uriWithB = "/uris-in-scala.html" addParams Foo(a = 1, b = Some("bar"))

--- a/shared/src/test/scala/io/lemonlabs/uri/TypesafeDslTypeTests.scala
+++ b/shared/src/test/scala/io/lemonlabs/uri/TypesafeDslTypeTests.scala
@@ -35,10 +35,7 @@ class TypesafeDslTypeTests extends AnyFlatSpec with Matchers {
 
   "Foo" should "render correctly as path part" in {
     final case class Foo(a: String, b: Int)
-    object Foo {
-      given pathPart: TraversablePathParts[Foo] =
-        TraversablePathParts.product
-    }
+    implicit val pathPart: TraversablePathParts[Foo] = TraversablePathParts.product
 
     val uri = "http://example.com" / Foo(a = "user", b = 1)
     uri.toString should equal("http://example.com/user/1")
@@ -56,9 +53,7 @@ class TypesafeDslTypeTests extends AnyFlatSpec with Matchers {
 
   "Foo" should "render correctly as query parameters" in {
     final case class Foo(a: String)
-    object Foo {
-      implicit val fooQueryKeyValue: QueryKeyValue[Foo] = QueryKeyValue(_ => "foo", foo => Option(foo.a))
-    }
+    implicit val fooQueryKeyValue: QueryKeyValue[Foo] = QueryKeyValue(_ => "foo", foo => Option(foo.a))
 
     val uri = "/uris-in-scala.html" ? Foo("foo_value")
     uri.toString should equal("/uris-in-scala.html?foo=foo_value")
@@ -66,10 +61,7 @@ class TypesafeDslTypeTests extends AnyFlatSpec with Matchers {
 
   "TraversableParams" should "derive type class for case class correctly" in {
     final case class Foo(a: Int, b: String)
-
-    object Foo {
-      given traversableParams: TraversableParams[Foo] = TraversableParams.product
-    }
+    implicit val traversableParams: TraversableParams[Foo] = TraversableParams.product
 
     val uri = "/uris-in-scala.html" addParams Foo(a = 1, b = "bar")
     uri.toString should equal("/uris-in-scala.html?a=1&b=bar")
@@ -77,16 +69,10 @@ class TypesafeDslTypeTests extends AnyFlatSpec with Matchers {
 
   "TraversableParams" should "derive type class for case classes structure correctly" in {
     final case class Foo(a: Int, b: String)
-
-    object Foo {
-      given traversableParams: TraversableParams[Foo] = TraversableParams.product
-    }
+    implicit val traversableParamsFoo: TraversableParams[Foo] = TraversableParams.product
 
     final case class Bar(c: Int, foo: Foo)
-
-    object Bar {
-      given traversableParams: TraversableParams[Bar] = TraversableParams.product
-    }
+    implicit val traversableParamsBar: TraversableParams[Bar] = TraversableParams.product
 
     val uri = "/uris-in-scala.html" addParams Bar(c = 2, foo = Foo(a = 1, b = "bar"))
     uri.toString should equal("/uris-in-scala.html?c=2&a=1&b=bar")
@@ -94,10 +80,7 @@ class TypesafeDslTypeTests extends AnyFlatSpec with Matchers {
 
   "TraversableParams" should "derive type class for case class with optional field correctly" in {
     final case class Foo(a: Int, b: Option[String])
-
-    object Foo {
-      given traversableParams: TraversableParams[Foo] = TraversableParams.product
-    }
+    implicit val traversableParamsFoo: TraversableParams[Foo] = TraversableParams.product
 
     val uriWithB = "/uris-in-scala.html" addParams Foo(a = 1, b = Some("bar"))
     val uriWithoutB = "/uris-in-scala.html" addParams Foo(a = 1, b = None)
@@ -126,9 +109,7 @@ class TypesafeDslTypeTests extends AnyFlatSpec with Matchers {
       val name: String = "B"
     }
 
-    object Foo {
-      implicit val queryValue: QueryValue[Foo] = QueryValue.derive[Foo].by(_.name)
-    }
+    implicit val queryValue: QueryValue[Foo] = QueryValue.derive[Foo].by(_.name)
 
     val uriA = "/uris-in-scala.html" ? ("foo" -> A)
     val uriB = "/uris-in-scala.html" ? ("foo" -> B)

--- a/shared/src/test/scala/io/lemonlabs/uri/UriScalaCheckGenerators.scala
+++ b/shared/src/test/scala/io/lemonlabs/uri/UriScalaCheckGenerators.scala
@@ -86,9 +86,9 @@ trait UriScalaCheckGenerators {
   // format: off
 
   implicit val randIpV6:Arbitrary[IpV6] =  {
-    val piece = Gen.chooseNum(0, Char.MaxValue)
+    val piece = Gen.chooseNum[Int](0, Char.MaxValue)
     Arbitrary(Gen.zip(piece, piece, piece, piece, piece, piece, piece, piece).map {
-      case (a, b, c, d, e, f, g, h) => IpV6(a, b, c, d, e, f, g, h)
+      case (a, b, c, d, e, f, g, h) => IpV6.apply(a, b, c, d, e, f, g, h)
     })
   }
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "3.5.0"
+ThisBuild / version := "4.0.0-M2"


### PR DESCRIPTION
Compiles for Scala 3, 2.13 and 2.12 (both JVM and Scala.js for all three).

Had to disable scoverage and running the Scala.js tests for now, but raised the following to track re-enabling both:
 - https://github.com/lemonlabsuk/scala-uri/issues/348
 - https://github.com/lemonlabsuk/scala-uri/issues/349
