### PR TITLE
Append scalacOptions rather than setting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,10 @@
 name: scala-uri CI
 
 on:
-  - push
-  - pull_request
+  push:
+    branches: [ "**" ]
+  pull_request:
+    branches: [ "**" ]
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: scala-uri CI
 
 on:
   push:
-    branches: [ "**" ]
+    branches: [ master ]
   pull_request:
-    branches: [ "**" ]
+    branches: [ master ]
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,8 @@
 name: scala-uri CI
 
 on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+  - push
+  - pull_request
 
 jobs:
   build:

--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ val sharedSettings = Seq(
     "org.scalacheck"    %%% "scalacheck"                      % "1.15.4"   % Test,
     "org.typelevel"     %%% "cats-laws"                       % "2.7.0"    % Test
   ),
-  scalacOptions := Seq(
+  scalacOptions ++= Seq(
     "-unchecked",
     "-deprecation",
     "-encoding",
@@ -175,7 +175,7 @@ lazy val docs = project
     // README.md has examples with expected compiler warnings (deprecated code, exhaustive matches)
     // Turn off these warnings to keep this noise down
     // We can remove this if the following is implemented https://github.com/scalameta/mdoc/issues/286
-    scalacOptions   := Seq("--no-warnings"),
+    scalacOptions   ++= Seq("--no-warnings"),
     publish / skip  := true,
     publishArtifact := false
   )


### PR DESCRIPTION
Fixes #395. Setting `scalacOptions` rather than appending meant that `.sjsir` files were missing from the scala.js jar for scala3. I'm not sure why, but this seems to fix it