### PR TITLE
Fix #399 Allow colons in paths again

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -51,7 +51,6 @@ val sharedSettings = Seq(
   semanticdbEnabled        := true,
   semanticdbVersion        := scalafixSemanticdb.revision,
   Test / parallelExecution := false,
-  scalafmtOnCompile        := true,
   coverageExcludedPackages := "(io.lemonlabs.uri.inet.Trie.*|io.lemonlabs.uri.inet.PublicSuffixes.*|io.lemonlabs.uri.inet.PublicSuffixTrie.*|io.lemonlabs.uri.inet.PunycodeSupport.*)"
 )
 

--- a/shared/src/main/scala/io/lemonlabs/uri/Path.scala
+++ b/shared/src/main/scala/io/lemonlabs/uri/Path.scala
@@ -82,6 +82,8 @@ sealed trait UrlPath extends Path {
   def toAbsolute: AbsolutePath
   def toAbsoluteOrEmpty: AbsoluteOrEmptyPath
 
+  def nonEmptyRootless: Boolean
+
   def withConfig(config: UriConfig): Self
 
   def addPart[P: PathPart](part: P): UrlPath =
@@ -220,6 +222,9 @@ case object EmptyPath extends AbsoluteOrEmptyPath {
   def isEmpty: Boolean =
     true
 
+  def nonEmptyRootless: Boolean =
+    false
+
   def withConfig(config: UriConfig): EmptyPath.type =
     this
 
@@ -267,6 +272,9 @@ final case class RootlessPath(parts: Vector[String])(implicit val config: UriCon
   def isEmpty: Boolean =
     parts.isEmpty
 
+  def nonEmptyRootless: Boolean =
+    parts.nonEmpty
+
   override def isSlashTerminated: Boolean = parts.lastOption.contains("")
 }
 
@@ -296,6 +304,9 @@ final case class AbsolutePath(parts: Vector[String])(implicit val config: UriCon
   /** Always returns false as we always have at least a leading slash
     */
   def isEmpty: Boolean =
+    false
+
+  def nonEmptyRootless: Boolean =
     false
 
   override private[uri] def toStringWithConfig(c: UriConfig): String =

--- a/shared/src/test/scala/io/lemonlabs/uri/GithubIssuesTests.scala
+++ b/shared/src/test/scala/io/lemonlabs/uri/GithubIssuesTests.scala
@@ -101,4 +101,16 @@ class GithubIssuesTests extends AnyFlatSpec with Matchers with OptionValues {
   "Github Issue #368" should "allow parsing of an empty query" in {
     QueryString.parseTry("") should equal(Success(QueryString.empty))
   }
+
+  "Github Issue #399" should "allow parsing paths with colons" in {
+    Url.parseTry("/this:1/does/not") should equal(
+      Success(RelativeUrl(AbsolutePath.fromParts("this:1", "does", "not"), QueryString.empty, None))
+    )
+  }
+
+  it should "allow parsing paths with square brackets" in {
+    Url.parseTry("/this[1]/does/not") should equal(
+      Success(RelativeUrl(AbsolutePath.fromParts("this[1]", "does", "not"), QueryString.empty, None))
+    )
+  }
 }

--- a/shared/src/test/scala/io/lemonlabs/uri/ParsingTests.scala
+++ b/shared/src/test/scala/io/lemonlabs/uri/ParsingTests.scala
@@ -149,7 +149,7 @@ class ParsingTests extends AnyFlatSpec with Matchers {
     val e = the[UriParsingException] thrownBy Url.parse(nineSegIp)
 
     // todo: Improve error messages to be closer to the parboiled2 message below
-    e.getMessage should equal("Invalid URL could not be parsed. Error(7,NonEmptyList(EndOfString(7,31)))")
+    e.getMessage should equal("Invalid URL could not be parsed. Error(31,NonEmptyList(Fail(31)))")
 //    e.getMessage should equal(
 //      """Invalid URL could not be parsed. Invalid input ']', expected HexDigit or ':' (line 1, column 26):
 //                                |http://[1:2:3:4:5:6:7:8:9]:9000


### PR DESCRIPTION
**Description**

Version `3.6.0` of scala-uri switched from using parboiled2 to cats-parse parsing library (to facilitate scala3 cross-compiling). Due to a hole in test coverage a regression was missed in the behaviour of path parsing where colons and square brackets were no longer allowed in path segments.

This PR adds test coverage and changes path parsing to be more closely inline with the parsing that was previously used with parboiled2. It also adds some explicit checks from RFC3986 1) paths not following an authority must not start `//` 2) the first path segment in relative urls must not contain `:`. (TBH I'm not sure how the tests were passing under parboiled2 without these checks 🤷)