### PR TITLE
Fix #486. DataUrl.parse to parse data: URLs with empty data

### DIFF
--- a/shared/src/main/scala/io/lemonlabs/uri/parsing/UrlParser.scala
+++ b/shared/src/main/scala/io/lemonlabs/uri/parsing/UrlParser.scala
@@ -220,7 +220,7 @@ class UrlParser(val input: String)(implicit conf: UriConfig = UriConfig.default)
       _ <- not(string("//"))
       media_type <- _media_type
       _ <- Parser.string(";base64,")
-      data <- Parser.until(Parser.end)
+      data <- Parser.until0(Parser.end)
     } yield extractBase64DataUrl(media_type, data)
 
   def _data_url_percent_encoded: Parser[DataUrl] =
@@ -232,7 +232,7 @@ class UrlParser(val input: String)(implicit conf: UriConfig = UriConfig.default)
       media_type <- _media_type
       _ <- Parser.char(';').?
       _ <- Parser.char(',')
-      data <- Parser.until(Parser.end)
+      data <- Parser.until0(Parser.end)
     } yield extractPercentEncodedDataUrl(media_type, data)
 
   def _data_url: Parser[DataUrl] =

--- a/shared/src/test/scala/io/lemonlabs/uri/DataUrlTests.scala
+++ b/shared/src/test/scala/io/lemonlabs/uri/DataUrlTests.scala
@@ -152,4 +152,30 @@ class DataUrlTests extends AnyFlatSpec with Matchers {
     val dataUrl = DataUrl.parse("data:,A%20brief%20note")
     dataUrl.dataAsString should equal("One&brief&note")
   }
+
+  "DataUrl.parse" should "return a DataUrl with empty data when there is no data in the path" in {
+    val dataUrl = DataUrl.parse("data:,")
+    dataUrl.data should equal(Array.empty[Byte])
+  }
+
+  "DataUrl.parse" should "return a DataUrl with empty data when there is empty Base64 encoded data" in {
+    val dataUrl = DataUrl.parse("data:text/plain;base64,")
+    dataUrl.data should equal(Array.empty[Byte])
+  }
+
+  "Url.parse" should "return a DataUrl when there is no data in the path" in {
+    val dataUrl = Url.parse("data:,")
+    dataUrl shouldBe a[DataUrl]
+    dataUrl.schemeOption should equal(Some("data"))
+    dataUrl.path.toStringRaw should equal(",")
+    dataUrl.path.toString() should equal(",")
+  }
+
+  "Url.parse" should "return a DataUrl when there is empty Base64 encoded data" in {
+    val dataUrl = Url.parse("data:;base64,")
+    dataUrl shouldBe a[DataUrl]
+    dataUrl.schemeOption should equal(Some("data"))
+    dataUrl.path.toStringRaw should equal(";base64,")
+    dataUrl.path.toString() should equal(";base64,")
+  }
 }


### PR DESCRIPTION
**Description**

Tweak to the URL parsing to allow data URLs with empty data, such as 'data:,' or 'data:;base64,'.

