### PR TITLE
Bump cats-parse to 1.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ pubring.gpg
 secring.gpg
 
 .bsp/
+.metals/
+.idea/
+.vscode/

--- a/build.sbt
+++ b/build.sbt
@@ -67,7 +67,7 @@ val scalaUriSettings = Seq(
   description := "Simple scala library for building and parsing URIs",
   libraryDependencies ++= Seq(
     "org.typelevel" %%% "cats-core"  % "2.9.0",
-    "org.typelevel" %%% "cats-parse" % "0.3.9"
+    "org.typelevel" %%% "cats-parse" % "1.0.0"
   ),
   libraryDependencies ++= (if (isScala3.value) Nil else Seq("com.chuusai" %%% "shapeless" % "2.3.10")),
   pomPostProcess := { node =>

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ import com.typesafe.tools.mima.plugin.MimaKeys.{mimaBinaryIssueFilters, mimaPrev
 
 name := "scala-uri root"
 
-ThisBuild / scalaVersion       := "3.2.2"
+ThisBuild / scalaVersion       := "3.3.5"
 ThisBuild / crossScalaVersions := Seq("2.12.17", "2.13.10", scalaVersion.value)
 publish / skip                 := true // Do not publish the root project
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.6")
 
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.1")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.12.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.13.0")
 
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")
 

--- a/shared/src/main/scala-3/io/lemonlabs/uri/typesafe/TraversableParamsDeriving.scala
+++ b/shared/src/main/scala-3/io/lemonlabs/uri/typesafe/TraversableParamsDeriving.scala
@@ -4,20 +4,21 @@ import scala.compiletime.{erasedValue, summonInline}
 import scala.deriving.Mirror
 
 trait TraversableParamsDeriving {
+  self: TraversableParamsConstructors =>
+
   inline def product[A](implicit m: Mirror.ProductOf[A]): TraversableParams[A] = {
     val elemInstances = summonAll[m.MirroredElemTypes]
 
-    new TraversableParams[A] {
-      override def toSeq(a: A): Seq[(String, Option[String])] =
-        a.asInstanceOf[Product]
-          .productElementNames
-          .zip(a.asInstanceOf[Product].productIterator)
-          .zip(elemInstances)
-          .flatMap {
-            case ((name, field), tc: QueryValue[_]) => Seq((name, tc.asInstanceOf[QueryValue[Any]].queryValue(field)))
-            case ((name, field), tc: TraversableParams[_]) => tc.asInstanceOf[TraversableParams[Any]].toSeq(field)
-          }
-          .toSeq
+    instance { (a: A) =>
+      a.asInstanceOf[Product]
+        .productElementNames
+        .zip(a.asInstanceOf[Product].productIterator)
+        .zip(elemInstances)
+        .flatMap {
+          case ((name, field), tc: QueryValue[_]) => Seq((name, tc.asInstanceOf[QueryValue[Any]].queryValue(field)))
+          case ((name, field), tc: TraversableParams[_]) => tc.asInstanceOf[TraversableParams[Any]].toSeq(field)
+        }
+        .toSeq
     }
   }
 

--- a/shared/src/main/scala-3/io/lemonlabs/uri/typesafe/TraversablePathPartsDeriving.scala
+++ b/shared/src/main/scala-3/io/lemonlabs/uri/typesafe/TraversablePathPartsDeriving.scala
@@ -4,16 +4,17 @@ import scala.compiletime.{erasedValue, summonInline}
 import scala.deriving.Mirror
 
 trait TraversablePathPartsDeriving {
+  self: TraversablePathPartsConstructors =>
+
   inline def product[A](implicit m: Mirror.ProductOf[A]): TraversablePathParts[A] = {
     val elemInstances = summonAll[m.MirroredElemTypes]
 
-    new TraversablePathParts[A] {
-      override def toSeq(a: A): Seq[String] =
-        a.asInstanceOf[Product]
-          .productIterator
-          .zip(elemInstances)
-          .flatMap { case (field, tc) => tc.asInstanceOf[TraversablePathParts[Any]].toSeq(field) }
-          .toSeq
+    instance { (a: A) =>
+      a.asInstanceOf[Product]
+        .productIterator
+        .zip(elemInstances)
+        .flatMap { case (field, tc) => tc.asInstanceOf[TraversablePathParts[Any]].toSeq(field) }
+        .toSeq
     }
   }
 

--- a/shared/src/main/scala/io/lemonlabs/uri/Uri.scala
+++ b/shared/src/main/scala/io/lemonlabs/uri/Uri.scala
@@ -25,7 +25,7 @@ import io.lemonlabs.uri.typesafe.TraversablePathParts.ops._
 import io.lemonlabs.uri.typesafe.Fragment.ops._
 
 import java.util
-import scala.util.Try
+import scala.util.{Failure, Try}
 
 /** Represents a URI. See [[https://www.ietf.org/rfc/rfc3986 RFC 3986]]
   *
@@ -105,11 +105,14 @@ object Uri {
     Some(uri.path)
 
   def parseTry(s: CharSequence)(implicit config: UriConfig = UriConfig.default): Try[Uri] =
-    Try(s.toString).flatMap(UriParser.parseUri)
+    if (s == null) {
+      Failure(new NullPointerException("Argument cannot be null"))
+    } else {
+      Try(s.toString).flatMap(UriParser.parseUri)
+    }
 
   def parseOption(s: CharSequence)(implicit config: UriConfig = UriConfig.default): Option[Uri] =
     parseTry(s).toOption
-
   def parse(s: CharSequence)(implicit config: UriConfig = UriConfig.default): Uri =
     parseTry(s).get
 

--- a/shared/src/main/scala/io/lemonlabs/uri/typesafe/PathPart.scala
+++ b/shared/src/main/scala/io/lemonlabs/uri/typesafe/PathPart.scala
@@ -80,6 +80,11 @@ sealed trait PathPartInstances extends PathPartInstances1 {
   implicit def optionPathPart[A: PathPart]: PathPart[Option[A]] = a => a.map(PathPart[A].path).getOrElse("")
 }
 
+sealed trait TraversablePathPartsConstructors {
+  def instance[A](toSeq: A => Seq[String]): TraversablePathParts[A] =
+    (a: A) => toSeq(a)
+}
+
 sealed trait TraversablePathPartsInstances {
   implicit def singleTraversablePathParts[A](implicit tc: PathPart[A]): TraversablePathParts[A] =
     a => tc.splitPath(a)
@@ -104,7 +109,10 @@ sealed trait TraversablePathPartsInstances {
     toSeq(a).toVector
 }
 
-object TraversablePathParts extends TraversablePathPartsInstances with TraversablePathPartsDeriving {
+object TraversablePathParts
+    extends TraversablePathPartsConstructors
+    with TraversablePathPartsInstances
+    with TraversablePathPartsDeriving {
   /* ======================================================================== */
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
   /* ======================================================================== */

--- a/shared/src/main/scala/io/lemonlabs/uri/typesafe/QueryKeyValue.scala
+++ b/shared/src/main/scala/io/lemonlabs/uri/typesafe/QueryKeyValue.scala
@@ -225,7 +225,7 @@ sealed trait QueryKeyValueInstances {
     toSeq(a).toVector
 }
 
-object TraversableParams extends TraversableParamsInstances with TraversableParamsDeriving {
+object TraversableParams extends TraversableParamsConstructors with TraversableParamsInstances with TraversableParamsDeriving {
   /* ======================================================================== */
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
   /* ======================================================================== */
@@ -268,6 +268,11 @@ object TraversableParams extends TraversableParamsInstances with TraversablePara
   /* END OF SIMULACRUM-MANAGED CODE                                           */
   /* ======================================================================== */
 
+}
+
+sealed trait TraversableParamsConstructors {
+  def instance[A](toSeq: A => Seq[(String, Option[String])]): TraversableParams[A] =
+    (a: A) => toSeq(a)
 }
 
 sealed trait TraversableParamsInstances1 {


### PR DESCRIPTION
Hey Ian! 👋 

Long time no see. I hope you're well.

I'm using scala-uri and finding it really useful. However, I'm also using cats-parse 1.0.0 and getting conflicts with the version used in scala-uri (0.3.4).

This PR makes minimal changes to haul cats-parse up to 1.0.0. I've had to bump ScalaJS by a minor version and Scala 3 by a couple of minor versions.

I've also made some small changes to silence a Scala 3 compiler warning and work around a weird bug in the JS code emitted by ScalaJS. There may be a saner fix to the latter - I'm afraid my ScalaJS knowledge is pretty minimal. 🤷